### PR TITLE
Add logging infrastructure

### DIFF
--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -1,6 +1,7 @@
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
+import logging
 
 from pyk.cli.utils import dir_path, file_path
 from pyk.ktool.kprint import KAstInput, KAstOutput
@@ -9,10 +10,15 @@ from pyk.utils import BugReport
 
 from .kmir import KMIR
 
+_LOGGER: Final = logging.getLogger(__name__)
+LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
+
 
 def main() -> None:
     parser = create_argument_parser()
     args = parser.parse_args()
+
+    logging.basicConfig(level=loglevel(args), format=LOG_FORMAT)
 
     executor_name = 'exec_' + args.command.lower().replace('-', '_')
     if executor_name not in globals():
@@ -75,11 +81,16 @@ def exec_run(
 
 
 def create_argument_parser() -> ArgumentParser:
+    logging_args = ArgumentParser(add_help=False)
+    logging_args.add_argument('--verbose', '-v', default=False, action='store_true', help='Verbose output.')
+    logging_args.add_argument('--debug', default=False, action='store_true', help='Debug output.')
+
     parser = ArgumentParser(prog='kmir', description='KMIR command line tool')
+
     command_parser = parser.add_subparsers(dest='command', required=True, help='Command to execute')
 
     # Init
-    init_subparser = command_parser.add_parser('init', help='Initialises a KMIR object')
+    init_subparser = command_parser.add_parser('init', parents=[logging_args], help='Initialises a KMIR object')
     init_subparser.add_argument(
         'llvm_dir',
         type=dir_path,
@@ -87,7 +98,7 @@ def create_argument_parser() -> ArgumentParser:
     )
 
     # Parse
-    parse_subparser = command_parser.add_parser('parse', help='Parse a MIR file')
+    parse_subparser = command_parser.add_parser('parse', parents=[logging_args], help='Parse a MIR file')
     parse_subparser.add_argument(
         'input_file',
         type=file_path,
@@ -120,7 +131,7 @@ def create_argument_parser() -> ArgumentParser:
     )
 
     # Run
-    run_subparser = command_parser.add_parser('run', help='Run a MIR program')
+    run_subparser = command_parser.add_parser('run', parents=[logging_args], help='Run a MIR program')
     run_subparser.add_argument(
         'input_file',
         type=file_path,
@@ -162,6 +173,16 @@ def create_argument_parser() -> ArgumentParser:
     )
 
     return parser
+
+
+def loglevel(args: Namespace) -> int:
+    if args.debug:
+        return logging.DEBUG
+
+    if args.verbose:
+        return logging.INFO
+
+    return logging.WARNING
 
 
 if __name__ == '__main__':

--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -1,7 +1,7 @@
+import logging
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from typing import Any, Final
-import logging
 
 from pyk.cli.utils import dir_path, file_path
 from pyk.ktool.kprint import KAstInput, KAstOutput

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -1,14 +1,14 @@
 __all__ = ['KMIR']
 
 import json
+import logging
 import os
 import subprocess
-import logging
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
 from tempfile import NamedTemporaryFile
-from typing import Optional, Union, Final, final
+from typing import Final, Optional, Union, final
 
 from pyk.cli.utils import check_dir_path, check_file_path
 from pyk.kast.inner import KInner

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -3,11 +3,12 @@ __all__ = ['KMIR']
 import json
 import os
 import subprocess
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
 from tempfile import NamedTemporaryFile
-from typing import Optional, Union, final
+from typing import Optional, Union, Final, final
 
 from pyk.cli.utils import check_dir_path, check_file_path
 from pyk.kast.inner import KInner
@@ -16,6 +17,8 @@ from pyk.ktool.krun import KRunOutput, _krun
 from pyk.utils import BugReport
 
 from .preprocessor import preprocess
+
+_LOGGER: Final = logging.getLogger(__name__)
 
 
 @final
@@ -54,7 +57,7 @@ class KMIR:
                 haskell_dir = Path(env_haskell_dir)
             else:
                 # Haskell dir doesn't exist, but it not needed for current functionality
-                print('WARN: Haskell defintion could not be found')
+                _LOGGER.warning('Haskell defintion could not be found')
                 haskell_dir = llvm_dir  # Just to pass type checking for now
         else:
             haskell_dir = Path(haskell_dir)


### PR DESCRIPTION
This PR enables running `kmir` with `--versbose` and `--debug` flags, which correspond to `INFO` and `DEBUG` Python log levels. Log messages are printed on `stderr` which makes them much better than `print` which may obstruct the normal tool output when redirecting it to a file.