### PR TITLE
Removing `init` from help menu

### DIFF
--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -36,6 +36,9 @@ def main() -> None:
 
 
 def exec_init(llvm_dir: str, **kwargs: Any) -> KMIR:
+    print(
+        'WARN: "init" was seen in args, this calls an internal function. If a file is named "init", it must be renamed'
+    )
     return KMIR(llvm_dir, llvm_dir)
 
 

--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -208,12 +208,14 @@ def create_argument_parser() -> ArgumentParser:
     command_parser = parser.add_subparsers(dest='command', required=True, help='Command to execute')
 
     # Init (See flake.nix)
-    init_subparser = command_parser.add_parser('init', parents=[logging_args])
-    init_subparser.add_argument(
-        'llvm_dir',
-        type=dir_path,
-        help='Path to the llvm definition',
-    )
+    # This command is not needed unless it is for the flake, so we should hide it from users
+    if 'init' in sys.argv:
+        init_subparser = command_parser.add_parser('init', parents=[logging_args])
+        init_subparser.add_argument(
+            'llvm_dir',
+            type=dir_path,
+            help='Path to the llvm definition',
+        )
 
     # Parse
     parse_subparser = command_parser.add_parser('parse', parents=[logging_args], help='Parse a MIR file')


### PR DESCRIPTION
`init` currently shows up in listed commands. But this is only needed for the `flake.nix` build. This edit will mean that it is not user facing