### PR TITLE
Added precedence to `LocalToken` to avoid conflict with `Identifier`

### DIFF
--- a/kmir/k-src/mir-lexer-syntax.md
+++ b/kmir/k-src/mir-lexer-syntax.md
@@ -19,7 +19,7 @@ This module defined the necessary `token` productions.
 
 ```k
   syntax IdentifierToken ::= r"[_a-zA-Z][_a-zA-Z0-9]*" [token]
-  syntax LocalToken      ::= r"_[0-9]+"  [token]
+  syntax LocalToken      ::= r"_[0-9]+" [prec(1), token]
 
   syntax BBId            ::= r"bb[0-9]+" [prefer, token]
 


### PR DESCRIPTION
When updating syntax and semantics, occasionally `Identifier` will match for a `Local`, this fix stops that happening.