### PR TITLE
`clean` before `build`

### DIFF
--- a/kmir/Makefile
+++ b/kmir/Makefile
@@ -19,7 +19,7 @@ clean:
 	find . -type d -name __pycache__ -prune -exec rm -rf {} \;
 
 .PHONY: build-backends
-build-backends: kbuild-llvm kbuild-haskell
+build-backends: clean kbuild-llvm kbuild-haskell
 
 .PHONY: build
 build: poetry-install build-backends


### PR DESCRIPTION
I ran into some issues extending the syntax and semantics where running `make build` carried through errors from the previous build. Removing `kdist/` and then `build` solved the problem. Unfortunately I don't have a reproducer for this.