### PR TITLE
Check correct k version is used for `Make` `build-backends`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
             checkGroups = [ ];
           };
         })
-      (final: prev: {
+      (let k_release = builtins.readFile ./deps/k_release; in final: prev: {
           mir-semantics = prev.stdenv.mkDerivation {
             pname = "mir-semantics";
             version = self.rev or "dirty";
@@ -58,14 +58,14 @@
             nativeBuildInputs = [ prev.makeWrapper ]; 
 
             src = ./kmir;
-            
+
             # kmir init $(kbuild which llvm) is to populate $out/lib/llvm
             # with parser_Mir_MIR-SYNTAX from gen_glr_parser 
             # before nix directory becomes read only
             buildPhase = ''
               export KBUILD_DIR=".kbuild"
-              ls
-              make build-backends POETRY_RUN=
+              patchShebangs .
+              make build-backends VERSION="${k_release}" POETRY_RUN=
               kmir init $(kbuild which llvm)
             '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,8 @@
             # before nix directory becomes read only
             buildPhase = ''
               export KBUILD_DIR=".kbuild"
-              make nix-build-backends POETRY_RUN=
+              ls
+              make build-backends POETRY_RUN=
               kmir init $(kbuild which llvm)
             '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
             # before nix directory becomes read only
             buildPhase = ''
               export KBUILD_DIR=".kbuild"
-              make build-backends POETRY_RUN=
+              make nix-build-backends POETRY_RUN=
               kmir init $(kbuild which llvm)
             '';
 

--- a/kmir/Makefile
+++ b/kmir/Makefile
@@ -132,3 +132,13 @@ check-k-version:
 
 .PHONY: kbuild-*
 
+# Nix (doesn't perform version check)
+
+.PHONY: nix-build-backends
+
+nix-build-backends: clean nix-kbuild-llvm nix-kbuild-haskell
+
+nix-kbuild-%:
+	$(POETRY_RUN) kbuild kompile $*
+
+.PHONY: nix-kbuild-*

--- a/kmir/Makefile
+++ b/kmir/Makefile
@@ -131,14 +131,3 @@ check-k-version:
 	./check_k_version.sh
 
 .PHONY: kbuild-*
-
-# Nix (doesn't perform version check)
-
-.PHONY: nix-build-backends
-
-nix-build-backends: clean nix-kbuild-llvm nix-kbuild-haskell
-
-nix-kbuild-%:
-	$(POETRY_RUN) kbuild kompile $*
-
-.PHONY: nix-kbuild-*

--- a/kmir/Makefile
+++ b/kmir/Makefile
@@ -127,7 +127,8 @@ kbuild-%: check-k-version
 kwhich-%:
 	$(POETRY_RUN) kbuild which $*
 
+# VERSION intended to be empty, unless building with nix
 check-k-version:
-	./check_k_version.sh
+	./check_k_version.sh $(VERSION)
 
 .PHONY: kbuild-*

--- a/kmir/Makefile
+++ b/kmir/Makefile
@@ -121,11 +121,14 @@ check-black: poetry-install
 
 # Kompilation
 
-kbuild-%:
+kbuild-%: check-k-version
 	$(POETRY_RUN) kbuild kompile $*
 
 kwhich-%:
 	$(POETRY_RUN) kbuild which $*
+
+check-k-version:
+	./check_k_version.sh
 
 .PHONY: kbuild-*
 

--- a/kmir/check_k_version.sh
+++ b/kmir/check_k_version.sh
@@ -2,7 +2,15 @@
 
 set -euo pipefail
 
-EXPECTED=$(cat ../deps/k_release)
+if [ $# -eq 0 ] 
+then
+    # No args given, check k_release directly
+    EXPECTED=$(cat ../deps/k_release)
+else
+    # Arg provided, must be nix providing version
+    EXPECTED=$1
+fi
+
 INSTALLED=$(kompile --version | head -1 | cut -f3 -dv)
 
 if grep -q "$EXPECTED" <<< "$INSTALLED"; 

--- a/kmir/check_k_version.sh
+++ b/kmir/check_k_version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+EXPECTED=$(cat ../deps/k_release)
+INSTALLED=$(kompile --version | head -1 | cut -f3 -dv)
+
+if grep -q "$EXPECTED" <<< "$INSTALLED"; 
+then
+    exit 0 
+else
+    echo "Installed K version $INSTALLED does not match required version $EXPECTED in deps/k_release"
+    echo "The correct version can be installed with:"
+    echo "    kup install k --version v$EXPECTED"
+    exit 1
+fi


### PR DESCRIPTION
This establishes a check that the correct version of `k` is installed, with instruction for how to install the correct version through `kup` if the wrong version is installed. This should protect developers from accidentally using the incorrect version, however it will also stop them from _intentionally_ using the incorrect version unless they change the script - an acceptable tradeoff.