### PR TITLE
Syntax/rigid ty update 1

### DIFF
--- a/kmir/k-src/mir-types.md
+++ b/kmir/k-src/mir-types.md
@@ -24,6 +24,7 @@ module MIR-TYPE-SYNTAX
                    | UintTy
                    | FloatTy
                    | "str"
+                   | ArrayType
 
   syntax IntTy ::= "isize"
                  | "i8"
@@ -69,7 +70,6 @@ module MIR-TYPE-SYNTAX
                                     // One option would be to replace all "&&"
                                     // tokens with "&" "&".
                                     | DoubleReferenceType
-                                    | ArrayType
                                     | SliceType
                                     | BareFunctionType
 
@@ -152,7 +152,7 @@ module MIR-TYPE-SYNTAX
   syntax LifetimeBounds ::= List{Lifetime, "+"}
 
   // https://doc.rust-lang.org/reference/types/array.html
-  syntax ArrayType ::= "[" Type ";" RustExpression "]" // HERE
+  syntax ArrayType ::= "[" Type ";" RustExpression "]"
 
   // https://doc.rust-lang.org/reference/types/slice.html
   syntax SliceType ::= "[" Type "]"

--- a/kmir/k-src/mir-types.md
+++ b/kmir/k-src/mir-types.md
@@ -23,6 +23,7 @@ module MIR-TYPE-SYNTAX
                    | IntTy
                    | UintTy
                    | FloatTy
+                   | "str"
 
   syntax IntTy ::= "isize"
                  | "i8"
@@ -360,6 +361,8 @@ module MIR-TYPE-SYNTAX
                         | "[" MaybeStatic "generator" "@" FilePosition "]"
   syntax MaybeStatic ::= "" | "static"
 
+  // Variable names can also clash with type names, see compiletest-rs/ui/moves/move-out-of-field.mir
+  // TODO: Handle this clash. See issue #228
   syntax UserVariableName ::= Identifier
   syntax AdtFieldName ::= Identifier
   syntax BBName ::= BBId

--- a/kmir/k-src/mir-types.md
+++ b/kmir/k-src/mir-types.md
@@ -19,10 +19,10 @@ module MIR-TYPE-SYNTAX
                 | TraitObjectTypeReduced
 
   syntax RigidTy ::= "bool"
-                  //  | "char" // TODO Errors
+                   | "char"
                    | IntTy
                    | UintTy
-                  //  | FloatTy // TODO Errors
+                   | FloatTy
 
   syntax IntTy ::= "isize"
                  | "i8"
@@ -38,8 +38,8 @@ module MIR-TYPE-SYNTAX
                   | "u64"
                   | "u128"
 
-  // syntax FloatTy ::= "f32" // TODO Errors
-  //                  | "f64"
+  syntax FloatTy ::= "f32"
+                   | "f64"
 
   syntax TypeList ::= List{Type, ","}
 

--- a/kmir/k-src/mir-types.md
+++ b/kmir/k-src/mir-types.md
@@ -24,7 +24,8 @@ module MIR-TYPE-SYNTAX
                    | UintTy
                    | FloatTy
                    | "str"
-                   | ArrayType
+                   | Array
+                   | Slice
 
   syntax IntTy ::= "isize"
                  | "i8"
@@ -70,7 +71,6 @@ module MIR-TYPE-SYNTAX
                                     // One option would be to replace all "&&"
                                     // tokens with "&" "&".
                                     | DoubleReferenceType
-                                    | SliceType
                                     | BareFunctionType
 
   // https://doc.rust-lang.org/reference/types/impl-trait.html
@@ -152,10 +152,10 @@ module MIR-TYPE-SYNTAX
   syntax LifetimeBounds ::= List{Lifetime, "+"}
 
   // https://doc.rust-lang.org/reference/types/array.html
-  syntax ArrayType ::= "[" Type ";" RustExpression "]"
+  syntax Array ::= "[" Type ";" RustExpression "]"
 
   // https://doc.rust-lang.org/reference/types/slice.html
-  syntax SliceType ::= "[" Type "]"
+  syntax Slice ::= "[" Type "]"
   // https://doc.rust-lang.org/reference/paths.html#qualified-paths
   syntax QualifiedPathInType ::= QualifiedPathType
   syntax QualifiedPathInType ::= QualifiedPathInType "::" TypePathSegment

--- a/kmir/src/tests/integration/test-data/compiletest-parse-fail.tsv
+++ b/kmir/src/tests/integration/test-data/compiletest-parse-fail.tsv
@@ -150,6 +150,7 @@ compiletest-rs/ui/autoref-autoderef/deref-into-array.mir	1
 compiletest-rs/ui/moves/move-3-unique.mir	1
 compiletest-rs/ui/moves/move-2.mir	1
 compiletest-rs/ui/moves/move-arg-2-unique.mir	1
+compiletest-rs/ui/moves/move-out-of-field.mir	1
 compiletest-rs/ui/moves/move-1-unique.mir	1
 compiletest-rs/ui/moves/move-2-unique.mir	1
 compiletest-rs/ui/moves/move-4.mir	1

--- a/kmir/src/tests/integration/test-data/compiletest-parse-fail.tsv
+++ b/kmir/src/tests/integration/test-data/compiletest-parse-fail.tsv
@@ -375,6 +375,7 @@ compiletest-rs/ui/consts/const-big-enum.mir	1
 compiletest-rs/ui/consts/const-enum-vector.mir	1
 compiletest-rs/ui/consts/self_normalization2.mir	1
 compiletest-rs/ui/consts/issue-27890.mir	1
+compiletest-rs/ui/consts/const-float-bits-conv.mir	1
 compiletest-rs/ui/consts/const-rec-and-tup.mir	1
 compiletest-rs/ui/consts/issue-21721.mir	1
 compiletest-rs/ui/consts/const-vec-of-fns.mir	1
@@ -388,6 +389,7 @@ compiletest-rs/ui/consts/const_let_assign2.mir	1
 compiletest-rs/ui/consts/const-size_of-align_of.mir	1
 compiletest-rs/ui/consts/issue-89088.mir	1
 compiletest-rs/ui/consts/const-block.mir	1
+compiletest-rs/ui/consts/const-float-classify.mir	1
 compiletest-rs/ui/consts/issue-13837.mir	1
 compiletest-rs/ui/consts/const-cast.mir	1
 compiletest-rs/ui/consts/const-enum-cast.mir	1


### PR DESCRIPTION
This update is to bring the syntax of `RigidTy` types in MIR closer to [stable mir](https://github.com/rust-lang/rust/blob/9ace9da2e050ff30f07a30323e5b3b3fcb63cd8f/compiler/stable_mir/src/ty.rs#L129-L149) and [smir](https://github.com/rust-lang/rust/blob/30d310cc1f7056fa9941b9f9c415d60091ed8fec/compiler/rustc_smir/src/rustc_smir/mod.rs#L1153). In particular this update introduces, `char`, `FloatTy`, and `str` types as explicit types (they were previously matching with `Identifier`), and it moves `ArrayType` and `SliceType` from `NonPathImplementableType` and drops `Type` from their names to be consistent with rust naming convention.

Three tests are added to failing, 2 are memory errors, and 1 is due to the error documented in #228 