### PR TITLE
Added evaluation of tuples.

### DIFF
--- a/kmir/k-src/mir-rvalue.md
+++ b/kmir/k-src/mir-rvalue.md
@@ -164,6 +164,7 @@ Evaluate a syntactic `RValue` into a semantics `RValueResult`. Inspired by [eval
   rule evalRValue(FN_KEY, BIN_OP:BinaryOp)  => evalBinaryOp(FN_KEY, BIN_OP)
   rule evalRValue(FN_KEY, ADDR:AddressOf)   => evalAddressOf(FN_KEY, ADDR)
   rule evalRValue(FN_KEY, CFD:CopyForDeref) => evalCopyForDeref(FN_KEY, CFD)
+  rule evalRValue(FN_KEY, TUP:Tuple)        => evalTuple(FN_KEY, TUP)
   rule evalRValue(_FN_KEY, RVALUE)          => Unsupported(RVALUE) [owise]
 ```
 
@@ -176,6 +177,11 @@ Evaluate a syntactic `RValue` into a semantics `RValueResult`. Inspired by [eval
   rule evalOperand(FN_KEY, LOCAL:Local)          => evalLocal(FN_KEY, LOCAL)
   rule evalOperand(FN_KEY, move LOCAL:Local)     => evalLocal(FN_KEY, LOCAL)
   rule evalOperand(FN_KEY, REF:Deref)            => evalDeref(FN_KEY, REF)
+
+  syntax MIRValueNeList ::= evalOperandList(FunctionLikeKey, OperandList) [function]
+  //--------------------------------------------------------------------------------
+  rule evalOperandList(_FN_KEY, .OperandList) => .MIRValueNeList
+  rule evalOperandList(FN_KEY, OPERAND:Operand, REST:OperandList) => evalOperand(FN_KEY, OPERAND), evalOperandList(FN_KEY, REST)
 ```
 
 ### `UnaryOp` evaluation
@@ -326,6 +332,14 @@ Locals only makes sense within a function-like, hence we evaluate them as a cont
   syntax MIRValue ::= evalCopyForDeref(FunctionLikeKey, CopyForDeref) [function]
   //----------------------------------------------------------------------------
   rule evalCopyForDeref(FN_KEY, deref_copy(DEREF:Deref)) => evalDeref(FN_KEY, DEREF)
+```
+
+### `Aggregate` evaluation
+
+```k
+  syntax MIRValue ::= evalTuple(FunctionLikeKey, Tuple) [function]
+  //--------------------------------------------------------------
+  rule evalTuple(FN_KEY, ( OPERANDS , OperandList )) => ( evalOperandList(FN_KEY, OPERANDS, OperandList) )
 ```
 
 ```k

--- a/kmir/k-src/mir-rvalue.md
+++ b/kmir/k-src/mir-rvalue.md
@@ -180,8 +180,8 @@ Evaluate a syntactic `RValue` into a semantics `RValueResult`. Inspired by [eval
 
   syntax MIRValueNeList ::= evalOperandList(FunctionLikeKey, OperandList) [function]
   //--------------------------------------------------------------------------------
-  rule evalOperandList(_FN_KEY, .OperandList) => .MIRValueNeList
-  rule evalOperandList(FN_KEY, OPERAND:Operand, REST:OperandList) => evalOperand(FN_KEY, OPERAND), evalOperandList(FN_KEY, REST)
+  rule evalOperandList(_FN_KEY, .OperandList) => .List
+  rule evalOperandList(FN_KEY, OPERAND:Operand, REST:OperandList) => ListItem(evalOperand(FN_KEY, OPERAND)) {evalOperandList(FN_KEY, REST)}:>List
 ```
 
 ### `UnaryOp` evaluation

--- a/kmir/k-src/mir-types.md
+++ b/kmir/k-src/mir-types.md
@@ -423,6 +423,7 @@ module MIR-VALUE
   imports BYTES
   imports MIR-TYPE-SYNTAX
   imports MIR-LEXER-SYNTAX
+  imports LIST
 
   syntax KItem ::= RValueResult
 ```
@@ -452,9 +453,8 @@ TODO: add more domain sorts
                     | "UNIMPLEMENTED"
 
   syntax RValueResult ::= MIRValue
-                        | MIRValueNeList
 
-  syntax MIRValueNeList ::= NeList{MIRValue, ","}
+  syntax MIRValueNeList ::= List
 ```
 
 The `InteprError` sort represent the errors that may occur while interpreting an `RValue` into `RValueResult` (inspired by [InterpError](https://github.com/rust-lang/rust/blob/bd43458d4c2a01af55f7032f7c47d7c8fecfe560/compiler/rustc_middle/src/mir/interpret/error.rs#L480)):

--- a/kmir/k-src/mir-types.md
+++ b/kmir/k-src/mir-types.md
@@ -448,12 +448,13 @@ TODO: add more domain sorts
                     | "Unit"
                     | Bool
                     | "Never"
+                    | "(" MIRValueNeList ")"
                     | "UNIMPLEMENTED"
 
   syntax RValueResult ::= MIRValue
                         | MIRValueNeList
 
-  syntax MIRValueNeList ::= MIRValue | MIRValue MIRValueNeList
+  syntax MIRValueNeList ::= NeList{MIRValue, ","}
 ```
 
 The `InteprError` sort represent the errors that may occur while interpreting an `RValue` into `RValueResult` (inspired by [InterpError](https://github.com/rust-lang/rust/blob/bd43458d4c2a01af55f7032f7c47d7c8fecfe560/compiler/rustc_middle/src/mir/interpret/error.rs#L480)):

--- a/kmir/src/tests/integration/test-data/handwritten-run-fail.tsv
+++ b/kmir/src/tests/integration/test-data/handwritten-run-fail.tsv
@@ -1,0 +1,2 @@
+handwritten-rust/tuples-simple.mir	4
+handwritten-rust/assert_eq.mir	4

--- a/kmir/src/tests/integration/test-data/handwritten-rust/assert_eq.mir
+++ b/kmir/src/tests/integration/test-data/handwritten-rust/assert_eq.mir
@@ -1,0 +1,57 @@
+// WARNING: This output format is intended for human consumers only
+// and is subject to change without notice. Knock yourself out.
+fn main() -> () {
+    let mut _0: ();
+    let _1: i32;
+    let mut _3: (&i32, &i32);
+    let mut _4: &i32;
+    let mut _5: &i32;
+    let mut _8: bool;
+    let mut _9: bool;
+    let mut _10: i32;
+    let mut _11: i32;
+    let _13: !;
+    let mut _14: std::option::Option<std::fmt::Arguments<'_>>;
+    scope 1 {
+        debug a => _1;
+        let _2: i32;
+        scope 2 {
+            debug b => _2;
+            let _6: &i32;
+            let _7: &i32;
+            scope 3 {
+                debug left_val => _6;
+                debug right_val => _7;
+                let _12: core::panicking::AssertKind;
+                scope 4 {
+                    debug kind => _12;
+                }
+            }
+        }
+    }
+
+    bb0: {
+        _1 = const 42_i32;
+        _2 = Add(const 3_i32, const 39_i32);
+        _4 = &_2;
+        _5 = &_1;
+        _3 = (move _4, move _5);
+        _6 = (_3.0: &i32);
+        _7 = (_3.1: &i32);
+        _10 = (*_6);
+        _11 = (*_7);
+        _9 = Eq(move _10, move _11);
+        _8 = Not(move _9);
+        switchInt(move _8) -> [0: bb2, otherwise: bb1];
+    }
+
+    bb1: {
+        _12 = core::panicking::AssertKind::Eq;
+        _14 = Option::<Arguments<'_>>::None;
+        _13 = core::panicking::assert_failed::<i32, i32>(move _12, _6, _7, move _14);
+    }
+
+    bb2: {
+        return;
+    }
+}

--- a/kmir/src/tests/integration/test-data/handwritten-rust/assert_eq.rs
+++ b/kmir/src/tests/integration/test-data/handwritten-rust/assert_eq.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let a = 42;
+    let b = 3 + 39;
+    
+    assert_eq!(b, a);
+}

--- a/kmir/src/tests/integration/test-data/handwritten-rust/tuples-simple.mir
+++ b/kmir/src/tests/integration/test-data/handwritten-rust/tuples-simple.mir
@@ -1,0 +1,31 @@
+// WARNING: This output format is intended for human consumers only
+// and is subject to change without notice. Knock yourself out.
+fn main() -> () {
+    let mut _0: ();
+    let _1: (i32, i32);
+    let mut _2: bool;
+    let mut _3: bool;
+    let mut _4: i32;
+    let mut _5: i32;
+    let mut _6: !;
+    scope 1 {
+        debug tup => _1;
+    }
+
+    bb0: {
+        _1 = (const 42_i32, const 99_i32);
+        _4 = (_1.0: i32);
+        _5 = (_1.1: i32);
+        _3 = Ne(move _4, move _5);
+        _2 = Not(move _3);
+        switchInt(move _2) -> [0: bb2, otherwise: bb1];
+    }
+
+    bb1: {
+        _6 = core::panicking::panic(const "assertion failed: tup.0 != tup.1");
+    }
+
+    bb2: {
+        return;
+    }
+}

--- a/kmir/src/tests/integration/test-data/handwritten-rust/tuples-simple.rs
+++ b/kmir/src/tests/integration/test-data/handwritten-rust/tuples-simple.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let tup:(i32, i32) = (42, 99);
+    
+    assert!(tup.0 != tup.1);
+}

--- a/kmir/src/tests/integration/test_run.py
+++ b/kmir/src/tests/integration/test_run.py
@@ -40,7 +40,7 @@ COMPILETEST_RUN_EXCLUDE = {
 }
 
 HANDWRITTEN_RUN_FAIL_FILE = TEST_DATA_DIR / 'handwritten-run-fail.tsv'
-HANDWRITTEN_RUN_FAIL = {test.split('\t')[0] for test in COMPILETEST_RUN_FAIL_FILE.read_text().splitlines()}
+HANDWRITTEN_RUN_FAIL = {test.split('\t')[0] for test in HANDWRITTEN_RUN_FAIL_FILE.read_text().splitlines()}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR only concerns the evaluation of tuples directly, e.g. `_2 = (const 1_usize, const 2_i32) `. Accessing the fields is left to a different PR. The test that is added will not be able to pass until the fields are implemented.