### PR TITLE
Added `no_expand_macros` flag for `krun`

### DIFF
--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -148,6 +148,7 @@ class KMIR:
                 pmap={'PGM': str(self.mir_parser)},
                 bug_report=self.bug_report,
                 depth=depth,
+                no_expand_macros=True,
             )
 
         def preprocess_and_run(program_file: Path, temp_file: Path) -> CompletedProcess:


### PR DESCRIPTION
Initial configuration has no macros so we should pass this flag.