### PR TITLE
457 - Add `kmir gen-spec` command

### DIFF
--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -69,12 +69,11 @@ def _kmir_gen_spec(opts: GenSpecOpts) -> None:
 
     kmir_kast, _ = parse_result
     config = tools.make_init_config(kmir_kast, opts.start_symbol)
-    config_with_cell_vars, subst = split_config_from(config)
+    config_with_cell_vars, _ = split_config_from(config)
 
     lhs = CTerm(config)
     new_k_cell = tools.kmir.Symbols.END_PROGRAM
-    subst['K_CELL'] = new_k_cell
-    rhs = CTerm(Subst(subst)(config_with_cell_vars))
+    rhs = CTerm(Subst({'K_CELL': new_k_cell})(config_with_cell_vars))
     claim, _ = cterm_build_claim(opts.input_file.stem, lhs, rhs)
 
     output_file = opts.output_file

--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -6,6 +6,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pyk.cterm import CTerm, cterm_build_claim
+from pyk.kast.inner import Subst
+from pyk.kast.manip import split_config_from
+from pyk.kast.outer import KFlatModule, KImport
+
 from kmir.build import semantics
 from kmir.convert_from_definition.v2parser import parse_json
 
@@ -24,6 +29,21 @@ class RunOpts(KMirOpts):
     start_symbol: str
 
 
+@dataclass
+class GenSpecOpts(KMirOpts):
+    input_file: Path
+    output_file: Path | None
+    start_symbol: str
+
+    def __init__(self, input_file: Path, output_file: str | None, start_symbol: str) -> None:
+        self.input_file = input_file
+        if output_file is None:
+            self.output_file = None
+        else:
+            self.output_file = Path(output_file).resolve()
+        self.start_symbol = start_symbol
+
+
 def _kmir_run(opts: RunOpts) -> None:
     tools = semantics()
 
@@ -39,11 +59,42 @@ def _kmir_run(opts: RunOpts) -> None:
     print(tools.kprint.kore_to_pretty(result))
 
 
+def _kmir_gen_spec(opts: GenSpecOpts) -> None:
+    tools = semantics()
+
+    parse_result = parse_json(tools.definition, opts.input_file, 'Pgm')
+    if parse_result is None:
+        print('Parse error!', file=sys.stderr)
+        sys.exit(1)
+
+    kmir_kast, _ = parse_result
+    config = tools.make_init_config(kmir_kast, opts.start_symbol)
+    config_with_cell_vars, subst = split_config_from(config)
+
+    lhs = CTerm(config)
+    new_k_cell = tools.kmir.Symbols.END_PROGRAM
+    subst['K_CELL'] = new_k_cell
+    rhs = CTerm(Subst(subst)(config_with_cell_vars))
+    claim, _ = cterm_build_claim(opts.input_file.stem, lhs, rhs)
+
+    output_file = opts.output_file
+    if output_file is None:
+        output_file = opts.input_file.with_suffix('.spec.json')
+
+    spec_module = KFlatModule(
+        opts.input_file.stem.upper().replace('.', '-').replace('_', '-'), (claim,), (KImport('KMIR'),)
+    )
+
+    output_file.write_text(spec_module.to_json())
+
+
 def kmir(args: Sequence[str]) -> None:
     opts = _parse_args(args)
     match opts:
         case RunOpts():
             _kmir_run(opts)
+        case GenSpecOpts():
+            _kmir_gen_spec(opts)
         case _:
             raise AssertionError()
 
@@ -60,6 +111,13 @@ def _arg_parser() -> ArgumentParser:
         '--start-symbol', type=str, metavar='SYMBOL', default='main', help='Symbol name to begin execution from'
     )
 
+    gen_spec_parser = command_parser.add_parser('gen-spec', help='Generate a k spec from a SMIR json')
+    gen_spec_parser.add_argument('input_file', metavar='FILE', help='MIR program to generate a spec for')
+    gen_spec_parser.add_argument('--output-file', metavar='FILE', help='Output file')
+    gen_spec_parser.add_argument(
+        '--start-symbol', type=str, metavar='SYMBOL', default='main', help='Symbol name to begin execution from'
+    )
+
     return parser
 
 
@@ -69,6 +127,10 @@ def _parse_args(args: Sequence[str]) -> KMirOpts:
     match ns.command:
         case 'run':
             return RunOpts(input_file=Path(ns.input_file).resolve(), depth=ns.depth, start_symbol=ns.start_symbol)
+        case 'gen-spec':
+            return GenSpecOpts(
+                input_file=Path(ns.input_file).resolve(), output_file=ns.output_file, start_symbol=ns.start_symbol
+            )
         case _:
             raise AssertionError()
 

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -2,14 +2,52 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pyk.kast.inner import KApply, KSequence
+from pyk.kcfg.semantics import DefaultSemantics
+from pyk.kcfg.show import NodePrinter
 from pyk.ktool.kprove import KProve
 from pyk.ktool.krun import KRun
+from pyk.proof.show import APRProofNodePrinter
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Final
+
+    from pyk.cterm import CTerm
+    from pyk.proof.reachability import APRProof
 
 
 class KMIR(KProve, KRun):
     def __init__(self, definition_dir: Path) -> None:
         KProve.__init__(self, definition_dir)
         KRun.__init__(self, definition_dir)
+
+    class Symbols:
+        END_PROGRAM: Final = KApply('#EndProgram_KMIR_KItem')
+
+
+class KMIRSemantics(DefaultSemantics):
+    def is_terminal(self, cterm: CTerm) -> bool:
+        k_cell = cterm.cell('K_CELL')
+        # <k> #EndProgram </k>
+        if k_cell == KMIR.Symbols.END_PROGRAM:
+            return True
+        elif type(k_cell) is KSequence:
+            # <k> #EndProgram ~> .K </k>
+            if k_cell.arity == 1 and k_cell[0] == KMIR.Symbols.END_PROGRAM:
+                return True
+        return False
+
+
+class KMIRNodePrinter(NodePrinter):
+    kmir: KMIR
+
+    def __init__(self, kmir: KMIR) -> None:
+        NodePrinter.__init__(self, kmir)
+        self.kmir = kmir
+
+
+class KMIRAPRNodePrinter(KMIRNodePrinter, APRProofNodePrinter):
+    def __init__(self, kmir: KMIR, proof: APRProof) -> None:
+        KMIRNodePrinter.__init__(self, kmir)
+        APRProofNodePrinter.__init__(self, proof, kmir)

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pyk.ktool.kprove import KProve
+from pyk.ktool.krun import KRun
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class KMIR(KProve, KRun):
+    def __init__(self, definition_dir: Path) -> None:
+        KProve.__init__(self, definition_dir)
+        KRun.__init__(self, definition_dir)

--- a/kmir/src/kmir/tools.py
+++ b/kmir/src/kmir/tools.py
@@ -50,16 +50,24 @@ class Tools:
         return self.__kmir
 
     @property
+    def kmir(self) -> KMIR:
+        return self.__kmir
+
+    @property
     def definition(self) -> KDefinition:
         return self.__definition
 
     def run_parsed(self, parsed_smir: KInner, start_symbol: KInner | str = 'main', depth: int | None = None) -> Pattern:
+        init_config = self.make_init_config(parsed_smir, start_symbol)
+        init_kore = self.krun.kast_to_kore(init_config, KSort('GeneratedTopCell'))
+        result = self.krun.run_pattern(init_kore, depth=depth)
+
+        return result
+
+    def make_init_config(self, parsed_smir: KInner, start_symbol: KInner | str = 'main') -> KInner:
         if isinstance(start_symbol, str):
             start_symbol = stringToken(start_symbol)
 
         subst = Subst({'$PGM': parsed_smir, '$STARTSYM': start_symbol})
         init_config = subst.apply(self.definition.init_config(KSort('GeneratedTopCell')))
-        init_kore = self.krun.kast_to_kore(init_config, KSort('GeneratedTopCell'))
-        result = self.krun.run_pattern(init_kore, depth=depth)
-
-        return result
+        return init_config

--- a/kmir/src/kmir/tools.py
+++ b/kmir/src/kmir/tools.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING
 
 from pyk.kast.inner import KSort, Subst
 from pyk.kast.outer import read_kast_definition
-from pyk.ktool.krun import KRun
 from pyk.prelude.string import stringToken
 
+from .kmir import KMIR
 from .kparse import KParse
 
 if TYPE_CHECKING:
@@ -16,11 +16,13 @@ if TYPE_CHECKING:
     from pyk.kast.outer import KDefinition
     from pyk.kore.syntax import Pattern
     from pyk.ktool.kprint import KPrint
+    from pyk.ktool.kprove import KProve
+    from pyk.ktool.krun import KRun
 
 
 class Tools:
     __kparse: KParse
-    __krun: KRun
+    __kmir: KMIR
     __definition: KDefinition
 
     def __init__(
@@ -28,7 +30,7 @@ class Tools:
         definition_dir: Path,
     ) -> None:
         self.__kparse = KParse(definition_dir)
-        self.__krun = KRun(definition_dir)
+        self.__kmir = KMIR(definition_dir)
         self.__definition = read_kast_definition(definition_dir / 'compiled.json')
 
     @property
@@ -37,11 +39,15 @@ class Tools:
 
     @property
     def kprint(self) -> KPrint:
-        return self.__krun
+        return self.__kmir
 
     @property
     def krun(self) -> KRun:
-        return self.__krun
+        return self.__kmir
+
+    @property
+    def kprove(self) -> KProve:
+        return self.__kmir
 
     @property
     def definition(self) -> KDefinition:


### PR DESCRIPTION
Progress for #457 

This adds a command `gen-spec` which takes an SMIR json file and generates a specification module with a claim that rewrites the initial configuration to the `#EndProgram` symbol on the k cell.