### PR TITLE
Build stable-mir-json in `make test-integration`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           container-name: mir-semantics-ci-${{ github.sha }}
       - name: 'Build stable-mir-json and kmir'
-        run: docker exec --user github-user mir-semantics-ci-${GITHUB_SHA} make stable-mir-json build
+        run: docker exec --user github-user mir-semantics-ci-${GITHUB_SHA} make build
       - name: 'Run integration tests'
         run: docker exec --user github-user mir-semantics-ci-${GITHUB_SHA} make test-integration
       - name: 'Tear down Docker'

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ smir-parse-tests: # build # commented out for CI's sake
 test-unit:
 	$(UV_RUN) pytest $(TOP_DIR)/kmir/src/tests/unit --maxfail=1 --verbose $(TEST_ARGS)
 
-test-integration: build
+test-integration: stable-mir-json build
 	$(UV_RUN) pytest $(TOP_DIR)/kmir/src/tests/integration --maxfail=1 --verbose \
 			--durations=0 --numprocesses=$(PARALLEL) --dist=worksteal $(TEST_ARGS)
 


### PR DESCRIPTION
When updating the project and attempting to run the integration tests on master I got an error in the python code constructing `SmirInfo`. The reason is that while `make test-integration` builds a kmir, it does not build `stable-mir-json`. It was confusing me since I had updated the submodule and the hashes were the same, and I could see there was a build and populated `.stable-mir-json` directory (it was stale). 

This PR moves the building of `stable-mir-json` into the make target `test-integration`. It should not increase performance cost if one is already build as cargo will report the project successfully build in `0.0` seconds and continue.

I modified the CI test suite accordingly.