### PR TITLE
Removed `Ty`s from `#applyBinOp`

### DIFF
--- a/kmir/src/tests/integration/data/prove-rs/sum-to-n-functions.rs
+++ b/kmir/src/tests/integration/data/prove-rs/sum-to-n-functions.rs
@@ -1,0 +1,22 @@
+fn sum_to_n(n: usize) -> usize {
+    let mut sum = 0;
+    let mut counter = n;
+
+    while counter > 0 {
+        sum += counter;
+        counter = counter - 1;
+    }
+    return sum;
+}
+
+fn test_sum_to_n() -> () {
+    let n = 10;
+    let golden = 55;
+    let success = sum_to_n(n) == golden;
+    assert!(success);
+}
+
+fn main() {
+    test_sum_to_n();
+    return ();
+}


### PR DESCRIPTION
### Context
I tried running the sum-to-n example we had in the `run-rs/functions/` test dir, and the proof was failing as it was `thunk`ing on `#applyBinOp` with two `typedLocals` that did not have the same type as one was `TyUnknown`. The `TyUnknown` was originating from the comparison value in the guard of the loop body as it was being moved and the local was updated to `Moved` losing the `Ty` information (as `typedLocal`s get their `Ty` from the local slot they are written to).

Here is a quick breakdown of the steps where you can see this if anyone would like to run the breaking program again:

<details>

```
// sum-to-n call node(21)

node(22) Locals[5] <- ListItem ( newLocal ( ty ( 25 ) , mutabilityMut ) ) // from #setUpCalleeData

node(55) Locals[5] <- ListItem ( typedValue ( Integer ( 10, 64, false ) , ty ( 25 ) , mutabilityMut ) ) // prior to first comparison with binOpGt for loop guard

node(64) Locals[5] <- ListItem ( Moved ) // move occurs into the arg for first evaluation of binOpGt for loop guard

// binOpGt is successful as types are known, but now Locals[5] is Moved and doesn't have type info

node(188) Locals[5] <- ListItem ( typedValue ( Integer ( 9, 64, false ) , TyUnknown , mutabilityNot ) ) // prior to second comparison with binOpGt for loop guard

node(197) Locals[5] <- ListItem ( Moved ) // move occurs into the arg for second evaluation of binOpGt for loop guard

node(202) #applyBinOp ( binOpGt , typedValue ( Integer ( 9 , 64 , false ) , TyUnknown , mutabilityNot ) , typedValue ( Integer ( 0 , 64 , false ) , ty ( 25 ) , mutabilityNot ) , false )
// Note above that first arg has TyUnknown as the Ty was lost after the first move

node(203) typedValue ( thunk ( #applyBinOp ( binOpGt , typedValue ( Integer ( 9 , 64 , false ) , TyUnknown , mutabilityNot ) , typedValue ( Integer ( 0 , 64 , false ) , ty ( 25 ) , mutabilityNot ) , false ) ) , TyUnknown , mutabilityNot )
// #applyBinOp needs Ty's to be the same so it wraps it in a thunk
```

</details>

### Changes
-  Added sum-to-n-functions.rs test to prove-rs (contains loop that will trigger the problem)
- Removed `Ty` checking from `#applyBinOp` for `isArithmetic` and `isComparison` operations.