### PR TITLE
Remove spans from crate tests

### DIFF
--- a/kmir/src/tests/integration/data/crate-tests/single-bin/a_module::twice.expected
+++ b/kmir/src/tests/integration/data/crate-tests/single-bin/a_module::twice.expected
@@ -1,7 +1,6 @@
 
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
-│   span: 0
 │
 │  (42 steps)
 ├─ 3 (split)

--- a/kmir/src/tests/integration/data/crate-tests/single-bin/main.expected
+++ b/kmir/src/tests/integration/data/crate-tests/single-bin/main.expected
@@ -1,7 +1,6 @@
 
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
-│   span: 0
 │
 │  (219 steps)
 ├─ 3 (terminal)

--- a/kmir/src/tests/integration/data/crate-tests/single-dylib/add.expected
+++ b/kmir/src/tests/integration/data/crate-tests/single-dylib/add.expected
@@ -1,7 +1,6 @@
 
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
-│   span: 0
 │
 │  (34 steps)
 ├─ 3 (split)

--- a/kmir/src/tests/integration/data/crate-tests/single-lib/testing::test_add_in_range.expected
+++ b/kmir/src/tests/integration/data/crate-tests/single-lib/testing::test_add_in_range.expected
@@ -1,7 +1,6 @@
 
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
-│   span: 0
 │
 │  (112 steps)
 ├─ 3 (split)
@@ -18,7 +17,6 @@
 ┃  │  (4 steps)
 ┃  └─ 6 (stuck, leaf)
 ┃      #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
-┃      span: 72
 ┃
 ┗━━┓ subst: .Subst
    ┃ constraint:

--- a/kmir/src/tests/integration/data/crate-tests/two-crate-bin/main.expected
+++ b/kmir/src/tests/integration/data/crate-tests/two-crate-bin/main.expected
@@ -1,7 +1,6 @@
 
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
-│   span: 0
 │
 │  (723 steps)
 ├─ 3 (terminal)

--- a/kmir/src/tests/integration/data/crate-tests/two-crate-dylib/test_crate1_with.expected
+++ b/kmir/src/tests/integration/data/crate-tests/two-crate-dylib/test_crate1_with.expected
@@ -1,7 +1,6 @@
 
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
-│   span: 0
 │
 │  (212 steps)
 ├─ 3 (terminal)

--- a/kmir/src/tests/integration/test_integration.py
+++ b/kmir/src/tests/integration/test_integration.py
@@ -150,7 +150,8 @@ def test_crate_examples(main_crate: Path, kmir: KMIR, update_expected_output: bo
             linked_file.parent, proof.id, full_printer=False, smir_info=None, omit_current_body=False
         )
         shower = APRProofShow(kmir.definition, node_printer=KMIRAPRNodePrinter(cterm_show, proof, display_opts))
-        show_res = '\n'.join(shower.show(proof))
+        spans_removed = [line for line in shower.show(proof) if 'span: ' not in line]
+        show_res = '\n'.join(spans_removed)
 
         assert_or_update_show_output(show_res, file, update=update_expected_output)
     os.unlink(linked_file)


### PR DESCRIPTION
Spans are flakey for the crate tests. For now we can just remove the spans from the show output, and properly update the ID in a later PR