### PR TITLE
Assign Ty IDs to all function items

### DIFF
--- a/kmir/src/kmir/smir.py
+++ b/kmir/src/kmir/smir.py
@@ -79,7 +79,17 @@ class SMIRInfo:
     @cached_property
     def function_symbols(self) -> dict[int, dict]:
         fnc_symbols = {ty: sym for ty, sym, *_ in self._smir['functions'] if type(ty) is int}
+        # by convention, Ty -1 is used for 'main' if it exists
         fnc_symbols[-1] = {'NormalSym': self.main_symbol}
+
+        # function items not present in the SMIR lookup table are added with negative Ty ID
+        missing = [name for name in self.items.keys() if {'NormalSym': name} not in fnc_symbols.values()]
+
+        fake_ty = -2
+        for name in missing:
+            fnc_symbols[fake_ty] = {'NormalSym': name}
+            fake_ty -= 1
+
         return fnc_symbols
 
     @cached_property

--- a/kmir/src/tests/integration/data/crate-tests/single-dylib/main-crate/src/lib.rs
+++ b/kmir/src/tests/integration/data/crate-tests/single-dylib/main-crate/src/lib.rs
@@ -8,13 +8,6 @@ fn assume(cond: bool) {
     if !cond { exit(0); }
 }
 
-// must call test_add_in_range for it to be discovered by linker
-pub fn expose_test() {
-    testing::test_add_in_range(0, 0);
-}
-
-
-
 pub mod testing {
     use super::*;
 

--- a/kmir/src/tests/integration/data/crate-tests/single-lib/main-crate/src/lib.rs
+++ b/kmir/src/tests/integration/data/crate-tests/single-lib/main-crate/src/lib.rs
@@ -8,13 +8,6 @@ fn assume(cond: bool) {
     if !cond { exit(0); }
 }
 
-// must call test_add_in_range for it to be discovered by linker
-pub fn expose_test() {
-    testing::test_add_in_range(0, 0);
-}
-
-
-
 pub mod testing {
     use super::*;
 

--- a/kmir/src/tests/integration/data/crate-tests/two-crate-dylib/main-crate/src/lib.rs
+++ b/kmir/src/tests/integration/data/crate-tests/two-crate-dylib/main-crate/src/lib.rs
@@ -1,14 +1,6 @@
 use crate1;
 use crate1::MyStruct;
 
-pub fn expose_tests() {
-    let result = test_crate1_with(0);
-
-    if let crate1::MyEnum::Bar(result2) = use_unwrap_enum(Some(crate1::MyEnum::Bar(42))) {
-        assert_eq!(result.int_field, result2);
-    }
-}
-
 pub fn test_crate1_with(i: isize) -> MyStruct {
     MyStruct::new(i, Some(crate1::MyEnum::Bar(i)))
 }


### PR DESCRIPTION
The function table in SMIR JSON currently only contains functions which are called from other functions within the crate. For library crates, there can be many functions in the crate that aren't iun the table, and for binary crates, `main` is usually missing.

Previously, only `main`'s symbol was added to the table.

This change assigns negative `Ty` IDs to every item which is not present in the function table.

As a result, then dead-item pruning code now works on all functions without crash.

The previous hack to expose start symbol functions was removed from the crate tests.

Fixes #619 