### PR TITLE
Adjust reference and pointer offsets within aggregate types and arrays

### DIFF
--- a/kmir/src/kmir/kdist/mir-semantics/lemmas/kmir-lemmas.md
+++ b/kmir/src/kmir/kdist/mir-semantics/lemmas/kmir-lemmas.md
@@ -51,6 +51,12 @@ If nothing is removed, the list remains the same. If all elements are removed, n
   rule #Ceil(range(L, A, B)) => #Ceil(L) #And #Ceil(A) #And #Ceil(B) #And {true #Equals A +Int B <=Int size(L)} [simplification]
 ```
 
+The `#mapOffset` function maps `#adjustRef` over a lists of `Value`s, leaving the list length unchanged.
+
+```k
+  rule size(#mapOffset(L, _)) => size(L) [simplification, preserves-definedness]
+```
+
 ## Simplifications for Int
 
 These are trivial simplifications driven by syntactic equality, which should be present upstream.

--- a/kmir/src/tests/integration/data/prove-rs/show/pointer-cast-length-test-fail.array_cast_test.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/pointer-cast-length-test-fail.array_cast_test.expected
@@ -29,25 +29,25 @@
    │
    │  (208 steps)
    ├─ 7
-   │   #traverseProjection ( toStack ( 1 , local ( 2 ) ) , Range ( range ( ARG_ARRAY1:L
+   │   #traverseProjection ( toStack ( 1 , local ( 2 ) ) , Range ( range ( #mapOffset (
    │   span: 87
    ┃
    ┃ (1 step)
    ┣━━┓
    ┃  │
    ┃  ├─ 8
-   ┃  │   #traverseProjection ( toStack ( 1 , local ( 2 ) ) , project:Value ( range ( ARG_
+   ┃  │   #traverseProjection ( toStack ( 1 , local ( 2 ) ) , project:Value ( range ( #map
    ┃  │   span: 87
    ┃  │
    ┃  │  (116 steps)
    ┃  └─ 10 (stuck, leaf)
-   ┃      #traverseProjection ( toLocal ( 5 ) , Range ( range ( ARG_ARRAY1:List , 0 , size
+   ┃      #traverseProjection ( toLocal ( 5 ) , Range ( range ( #mapOffset ( ARG_ARRAY1:Li
    ┃      span: 97
    ┃
    ┗━━┓
       │
       └─ 9 (stuck, leaf)
-          #traverseProjection ( toStack ( 1 , local ( 2 ) ) , Range ( range ( ARG_ARRAY1:L
+          #traverseProjection ( toStack ( 1 , local ( 2 ) ) , Range ( range ( #mapOffset (
           span: 87
 
 

--- a/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.eats_all_args.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.eats_all_args.expected
@@ -45,14 +45,14 @@
 ┃     │
 ┃     │  (119 steps)
 ┃     ├─ 13
-┃     │   #traverseProjection ( toStack ( 1 , local ( 12 ) ) , Range ( ARG_ARRAY8:List ) ,
+┃     │   #traverseProjection ( toStack ( 1 , local ( 12 ) ) , Range ( #mapOffset ( ARG_AR
 ┃     │   span: 69
 ┃     ┃
 ┃     ┃ (1 step)
 ┃     ┣━━┓
 ┃     ┃  │
 ┃     ┃  ├─ 16
-┃     ┃  │   #traverseProjection ( toStack ( 1 , local ( 12 ) ) , project:Value ( ARG_ARRAY8:
+┃     ┃  │   #traverseProjection ( toStack ( 1 , local ( 12 ) ) , project:Value ( #mapOffset
 ┃     ┃  │   span: 69
 ┃     ┃  │
 ┃     ┃  │  (7 steps)
@@ -60,7 +60,7 @@
 ┃     ┃  │   #EndProgram ~> .K
 ┃     ┃  │
 ┃     ┃  ┊  constraint:
-┃     ┃  ┊      Ceil_d21c965f
+┃     ┃  ┊      Ceil_a90d0b00
 ┃     ┃  ┊  subst: ...
 ┃     ┃  └─ 2 (leaf, target, terminal)
 ┃     ┃      #EndProgram ~> .K
@@ -68,7 +68,7 @@
 ┃     ┗━━┓
 ┃        │
 ┃        └─ 17 (stuck, leaf)
-┃            #traverseProjection ( toStack ( 1 , local ( 12 ) ) , Range ( ARG_ARRAY8:List ) ,
+┃            #traverseProjection ( toStack ( 1 , local ( 12 ) ) , Range ( #mapOffset ( ARG_AR
 ┃            span: 69
 ┃
 ┗━━┓ subst: .Subst
@@ -108,14 +108,14 @@
       │
       │  (119 steps)
       ├─ 15
-      │   #traverseProjection ( toStack ( 1 , local ( 12 ) ) , Range ( ARG_ARRAY8:List ) ,
+      │   #traverseProjection ( toStack ( 1 , local ( 12 ) ) , Range ( #mapOffset ( ARG_AR
       │   span: 69
       ┃
       ┃ (1 step)
       ┣━━┓
       ┃  │
       ┃  ├─ 18
-      ┃  │   #traverseProjection ( toStack ( 1 , local ( 12 ) ) , project:Value ( ARG_ARRAY8:
+      ┃  │   #traverseProjection ( toStack ( 1 , local ( 12 ) ) , project:Value ( #mapOffset
       ┃  │   span: 69
       ┃  │
       ┃  │  (7 steps)
@@ -123,7 +123,7 @@
       ┃  │   #EndProgram ~> .K
       ┃  │
       ┃  ┊  constraint:
-      ┃  ┊      Ceil_d21c965f
+      ┃  ┊      Ceil_a90d0b00
       ┃  ┊  subst: ...
       ┃  └─ 2 (leaf, target, terminal)
       ┃      #EndProgram ~> .K
@@ -131,7 +131,7 @@
       ┗━━┓
          │
          └─ 19 (stuck, leaf)
-             #traverseProjection ( toStack ( 1 , local ( 12 ) ) , Range ( ARG_ARRAY8:List ) ,
+             #traverseProjection ( toStack ( 1 , local ( 12 ) ) , Range ( #mapOffset ( ARG_AR
              span: 69
 
 


### PR DESCRIPTION
Fixes a bug where references and pointers contained within container types would become invalid when passed between functions as arguments or read through other references.

Also included: Renaming of `VoidType` to `typeInfoVoidType`