### PR TITLE
Hotfix Ref with invalid offset

### DIFF
--- a/kmir/src/tests/integration/data/prove-rs/raw-ptr-aggregate.rs
+++ b/kmir/src/tests/integration/data/prove-rs/raw-ptr-aggregate.rs
@@ -1,0 +1,12 @@
+use std::slice::from_raw_parts;
+
+fn main() {
+    let mut arr = [0;3];
+    arr[1] = 1;
+    arr[2] = 2;
+    let arr2 = unsafe { from_raw_parts((&arr).as_ptr(), 2) };
+    //let arr2 = unsafe { from_raw_parts((&arr).as_ptr().add(1), 2) };
+    assert!(arr2.len() == 2);
+    assert!(arr2[0] + 1 == arr[1]);
+    assert!(arr2[1] + 1 == arr[2]);
+}

--- a/kmir/src/tests/integration/data/prove-rs/show/pointer-cast-length-test-fail.array_cast_test.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/pointer-cast-length-test-fail.array_cast_test.expected
@@ -39,7 +39,7 @@
    ┃  │   #traverseProjection ( toStack ( 1 , local ( 2 ) ) , project:Value ( range ( #map
    ┃  │   span: 87
    ┃  │
-   ┃  │  (116 steps)
+   ┃  │  (115 steps)
    ┃  └─ 10 (stuck, leaf)
    ┃      #traverseProjection ( toLocal ( 5 ) , Range ( range ( #mapOffset ( ARG_ARRAY1:Li
    ┃      span: 97

--- a/kmir/src/tests/integration/data/prove-smir/show/pinocchio_token_program.smir.processor::transfer::process_transfer.expected
+++ b/kmir/src/tests/integration/data/prove-smir/show/pinocchio_token_program.smir.processor::transfer::process_transfer.expected
@@ -31,7 +31,7 @@
    ├─ 5
    │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 2 ) )
    │
-   │  (417 steps)
+   │  (414 steps)
    ├─ 7 (split)
    │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 6 ) )
    ┃


### PR DESCRIPTION
The rules for returning values from functions are decrementing offsets of references and pointers.
This is wrong in case of a reference to the same stack frame (offset 0).
Rather than trying to catch this case in the return rule(s), we avoid creating these references in the first place:
* The compiler will prevent local variable references from escaping the scope.
* Therefore, the only way a reference to another local may be returned is that it's pointee is itself another reference or pointer, and is  _dereferenced_ by the reference's projection.
* The `RValue::AddressOf` rules already have a special case of creating a pointer from a dereferenced reference. What was missing is a dual rule for the case of a reference created from a dereferenced pointer.

The added test program is also a test for `AggregateKind::RawPtr` from the previous change #646 , as the problem was surfacing in founction `core::ptr::from_raw_parts`.