### PR TITLE
Add prent support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,15 +163,15 @@ uv --directory kmir run kmir show proof_id --full-printer --no-omit-static-info 
 ## K Framework Development Tips
 
 ### Compilation Issues
-- **Build timeouts**: K compilation should complete within 60 seconds. If builds timeout or hang indefinitely, check for leftover `.lock` files in the cache directory (`/home/user/.cache/kdist-*`)
-- **Cache cleanup**: Run `rm -rf ~/.cache/kdist-*` to clear compilation cache if experiencing persistent build issues
+- **Build timeouts**: K compilation should complete within 60 seconds. If builds timeout or hang indefinitely, check for leftover `.lock` files in the compilation cache directory
+- **Cache cleanup**: Find the specific cache directory with `uv --directory kmir run kdist which mir-semantics.llvm` (remove `/llvm` suffix), then delete only that directory to clear compilation cache
 - **Clean builds**: Use `make clean` to remove build artifacts before rebuilding
 
 ### K Semantics Patterns
-- **seqstrict attribute**: Use `seqstrict(N)` to evaluate the Nth parameter of a function before applying rules. For example, `seqstrict(5)` evaluates the 5th parameter to a `Value`
+- **seqstrict attribute**: Use `seqstrict(N)` to evaluate the Nth parameter before applying rules. The `Evaluation` sort is used for automatic evaluation ("heating" and "cooling") until `Value` is obtained. Rewrite symbols must declare `Evaluation` arguments for parameters that need evaluation.
 - **operandCopy evaluation**: Use `operandCopy(PLACE)` as an argument to `seqstrict` functions to evaluate place contents to `Value`
 - **Function vs KItem**: Functions (`[function]`) are pure and cannot access configuration; KItems can access configuration cells but require rules
-- **Pattern matching**: Rules should match specific data constructors rather than using catch-all patterns for better error detection
+- **Specific pattern matching**: Rules should match specific data constructors rather than using catch-all patterns. Execution should get stuck on unexpected data or unimplemented features rather than silently continuing
 
 ### Working with Inlined Functions
 When Rust functions are inlined, they may not appear in MIR as function calls:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,3 +159,22 @@ uv --directory kmir run kmir show proof_id --full-printer --no-omit-static-info 
 - `Function not found` errors: Check if function is in `FUNCTIONS_CELL` (may be intrinsic)
 - K compilation errors: Rules must be properly formatted, check syntax
 - SMIR generation fails: Ensure using correct Rust nightly version (2024-11-29)
+
+## K Framework Development Tips
+
+### Compilation Issues
+- **Build timeouts**: K compilation should complete within 60 seconds. If builds timeout or hang indefinitely, check for leftover `.lock` files in the cache directory (`/home/user/.cache/kdist-*`)
+- **Cache cleanup**: Run `rm -rf ~/.cache/kdist-*` to clear compilation cache if experiencing persistent build issues
+- **Clean builds**: Use `make clean` to remove build artifacts before rebuilding
+
+### K Semantics Patterns
+- **seqstrict attribute**: Use `seqstrict(N)` to evaluate the Nth parameter of a function before applying rules. For example, `seqstrict(5)` evaluates the 5th parameter to a `Value`
+- **operandCopy evaluation**: Use `operandCopy(PLACE)` as an argument to `seqstrict` functions to evaluate place contents to `Value`
+- **Function vs KItem**: Functions (`[function]`) are pure and cannot access configuration; KItems can access configuration cells but require rules
+- **Pattern matching**: Rules should match specific data constructors rather than using catch-all patterns for better error detection
+
+### Working with Inlined Functions
+When Rust functions are inlined, they may not appear in MIR as function calls:
+- Look for the non-inlined version (e.g., `from_bytes_unchecked` instead of `from_bytes`)
+- Check the actual Rust source code to understand what gets inlined vs what remains as function calls
+- Inlined functions may require handling their logic (like length checks) in the semantics rather than intercepting calls

--- a/kmir/src/kmir/kdist/mir-semantics/symbolic/p-token.md
+++ b/kmir/src/kmir/kdist/mir-semantics/symbolic/p-token.md
@@ -604,11 +604,7 @@ NB Both `load_unchecked` and `load_mut_unchecked` are intercepted in the same wa
     <functions> FUNCTIONS </functions>
     requires #tyOfCall(FUNC) in_keys(FUNCTIONS)
      andBool isMonoItemKind(FUNCTIONS[#tyOfCall(FUNC)])
-     andBool (
-          #functionName({FUNCTIONS[#tyOfCall(FUNC)]}:>MonoItemKind) ==String "pinocchio::sysvars::rent::load_unchecked::<pinocchio::sysvars::rent::Rent>"
-        orBool
-          #functionName({FUNCTIONS[#tyOfCall(FUNC)]}:>MonoItemKind) ==String "pinocchio::sysvars::rent::load_mut_unchecked::<pinocchio::sysvars::rent::Rent>"
-     )
+     andBool #functionName({FUNCTIONS[#tyOfCall(FUNC)]}:>MonoItemKind) ==String "pinocchio::sysvars::rent::Rent::from_bytes"
     [priority(30), preserves-definedness]
 
   // expect the Evaluation to return a `PAccByteRef` referring to a `PAccount<Thing>` (not checked)


### PR DESCRIPTION
* Intercepting `pinocchio::sysvars::rent::Rent::from_bytes_unchecked`
* adding a `PtrMetadata` rule and length parameter to `PAccByteRef` (requires evaluating the data behind it)
* includes some adjustments to `CLAUDE.md` file that could be cherry-picked separately. The code had to be manually adjusted after Claude, though.
