### PR TITLE
Add `nix-cache` and `nix-binary-cache` as `tag-release` CI job deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
 
   tag-release:
     runs-on: [ self-hosted, linux ]
-    needs: [ release-docker ]
+    needs: [ release-docker, nix-cache, nix-binary-cache ]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `tag-release` CI job was missing the new jobs `nix-cache` and `nix-binary-cache` as dependencies for the `tag-release` CI job.