### PR TITLE
Partially decode allocations in Python

### DIFF
--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -16,7 +16,7 @@ from pyk.proof.tui import APRProofViewer
 
 from .build import HASKELL_DEF_DIR, LLVM_DEF_DIR, LLVM_LIB_DIR
 from .cargo import CargoProject
-from .kmir import KMIR, KMIRAPRNodePrinter
+from .kmir import KMIR, DecodeMode, KMIRAPRNodePrinter
 from .linker import link
 from .options import (
     GenSpecOpts,
@@ -352,6 +352,13 @@ def _arg_parser() -> ArgumentParser:
     prove_rs_parser.add_argument(
         '--start-symbol', type=str, metavar='SYMBOL', default='main', help='Symbol name to begin execution from'
     )
+    prove_rs_parser.add_argument(
+        '--decode-mode',
+        type=DecodeMode,
+        metavar='DECODE_MODE',
+        default=DecodeMode.NONE,
+        help='Allocation decoding mode: NONE (default), PARTIAL, or FULL',
+    )
 
     link_parser = command_parser.add_parser(
         'link', help='Link together 2 or more SMIR JSON files', parents=[kcli_args.logging_args]
@@ -428,6 +435,7 @@ def _parse_args(ns: Namespace) -> KMirOpts:
                 save_smir=ns.save_smir,
                 smir=ns.smir,
                 start_symbol=ns.start_symbol,
+                decode_mode=ns.decode_mode,
             )
         case 'link':
             return LinkOpts(

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -158,9 +158,7 @@ class KMIR(KProve, KRun, KParse):
         done: dict[KInner, KInner] = {}
         rest: list[KInner] = []
 
-        allocs_json = smir_info._smir['allocs']
-        assert isinstance(allocs_json, list)
-        for alloc in allocs_json:
+        for alloc in smir_info._smir['allocs']:
             parse_result = parser.parse_mir_json(alloc, 'GlobalAlloc')
             assert parse_result is not None
             a, _ = parse_result

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -151,13 +151,13 @@ class KMIR(KProve, KRun, KParse):
                 terms=allocs,
             )
 
-        from pyk.kast.prelude.collections import map_empty
+        from pyk.kast.prelude.collections import map_of
 
         parser = Parser(self.definition)
 
-        done = map_empty()
-
+        done: dict[KInner, KInner] = {}
         rest: list[KInner] = []
+
         allocs_json = smir_info._smir['allocs']
         assert isinstance(allocs_json, list)
         for alloc in allocs_json:
@@ -166,7 +166,7 @@ class KMIR(KProve, KRun, KParse):
             a, _ = parse_result
             rest.append(a)
 
-        return done, global_allocs(rest)
+        return map_of(done), global_allocs(rest)
 
     def _make_function_map(self, smir_info: SMIRInfo) -> KInner:
         parsed_terms: dict[KInner, KInner] = {}

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -137,14 +137,11 @@ class KMIR(KProve, KRun, KParse):
     def _decode_allocs(self, smir_info: SMIRInfo) -> tuple[KInner, KInner]:
         from pyk.kast.prelude.collections import map_empty
 
-        done = map_empty()
-        rest = self._make_allocs_map(smir_info)
-
-        return done, rest
-
-    def _make_allocs_map(self, smir_info: SMIRInfo) -> KInner:
         parser = Parser(self.definition)
-        allocs: KInner = KApply('GlobalAllocs::empty')
+
+        done = map_empty()
+
+        rest: KInner = KApply('GlobalAllocs::empty')
         allocs_json = smir_info._smir['allocs']
         assert isinstance(allocs_json, list)
         allocs_json.reverse()
@@ -152,8 +149,9 @@ class KMIR(KProve, KRun, KParse):
             parse_result = parser.parse_mir_json(alloc, 'GlobalAlloc')
             assert parse_result is not None
             a, _ = parse_result
-            allocs = KApply('GlobalAllocs::append', (a, allocs))
-        return allocs
+            rest = KApply('GlobalAllocs::append', (a, rest))
+
+        return done, rest
 
     def _make_function_map(self, smir_info: SMIRInfo) -> KInner:
         parsed_terms: dict[KInner, KInner] = {}

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -131,8 +131,16 @@ class KMIR(KProve, KRun, KParse):
         return (subst.apply(config), constraints)
 
     def _make_memory_term(self, smir_info: SMIRInfo, types: KInner) -> KInner:
-        allocs = self._make_allocs_map(smir_info)
-        return KApply('decodeAllocs', (allocs, types))
+        done, rest = self._decode_allocs(smir_info)
+        return KApply('decodeAllocsAux', done, rest, types)
+
+    def _decode_allocs(self, smir_info: SMIRInfo) -> tuple[KInner, KInner]:
+        from pyk.kast.prelude.collections import map_empty
+
+        done = map_empty()
+        rest = self._make_allocs_map(smir_info)
+
+        return done, rest
 
     def _make_allocs_map(self, smir_info: SMIRInfo) -> KInner:
         parser = Parser(self.definition)

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -202,7 +202,18 @@ class KMIR(KProve, KRun, KParse):
             alloc_info = smir_info.allocs[alloc_id]
             value = decode_alloc_or_unable(alloc_info=alloc_info, types=smir_info.types)
 
-            if decode_mode is DecodeMode.FULL or not isinstance(value, (UnableToDecodeValue, UnableToDecodeAlloc)):
+            success: bool
+            match value:
+                case UnableToDecodeValue(data, type_info):
+                    _LOGGER.debug(f'Unable to decode value: {data!r}; of type: {type_info}')
+                    success = False
+                case UnableToDecodeAlloc():
+                    _LOGGER.debug(f'Unable to decode allocation: {alloc_info}')
+                    success = False
+                case _:
+                    success = True
+
+            if success or decode_mode is DecodeMode.FULL:
                 alloc_id_term = KApply('allocId', intToken(alloc_id))
                 return Decoded(alloc_id=alloc_id_term, value=value.to_kast())
 

--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -158,11 +158,11 @@ class KMIR(KProve, KRun, KParse):
         done: dict[KInner, KInner] = {}
         rest: list[KInner] = []
 
-        for alloc in smir_info._smir['allocs']:
-            parse_result = parser.parse_mir_json(alloc, 'GlobalAlloc')
-            assert parse_result is not None
-            a, _ = parse_result
-            rest.append(a)
+        for raw_alloc in smir_info._smir['allocs']:
+            parse_res = parser.parse_mir_json(raw_alloc, 'GlobalAlloc')
+            assert parse_res is not None
+            kast_alloc, _ = parse_res
+            rest.append(kast_alloc)
 
         return map_of(done), global_allocs(rest)
 

--- a/kmir/src/kmir/kparse.py
+++ b/kmir/src/kmir/kparse.py
@@ -16,8 +16,6 @@ if TYPE_CHECKING:
 
 
 class KParse(KPrint):
-    parser: str
-
     def __init__(
         self,
         definition_dir: Path,
@@ -25,7 +23,6 @@ class KParse(KPrint):
         bug_report: BugReport | None = None,
         extra_unparsing_modules: Iterable[KFlatModule] = (),
         patch_symbol_table: Callable[[SymbolTable], None] | None = None,
-        command: str = 'kparse',
     ):
         super().__init__(
             definition_dir,
@@ -34,7 +31,6 @@ class KParse(KPrint):
             extra_unparsing_modules=extra_unparsing_modules,
             patch_symbol_table=patch_symbol_table,
         )
-        self.parser = command
 
     def kparse(self, input_file: Path, *, sort: str) -> tuple[int, KInner]:
         returncode, kore = self.kparse_into_kore(input_file, sort=sort)

--- a/kmir/src/kmir/options.py
+++ b/kmir/src/kmir/options.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 from pyk.cli.args import LoggingOptions
 
+from .kmir import DecodeMode
+
 if TYPE_CHECKING:
     from typing import Final
 
@@ -77,6 +79,7 @@ class ProveRSOpts(ProveOpts):
     save_smir: bool
     smir: bool
     start_symbol: str
+    decode_mode: DecodeMode
 
     def __init__(
         self,
@@ -89,6 +92,7 @@ class ProveRSOpts(ProveOpts):
         save_smir: bool = False,
         smir: bool = False,
         start_symbol: str = 'main',
+        decode_mode: DecodeMode = DecodeMode.NONE,
     ) -> None:
         self.rs_file = rs_file
         self.proof_dir = Path(proof_dir).resolve() if proof_dir is not None else None
@@ -99,6 +103,7 @@ class ProveRSOpts(ProveOpts):
         self.save_smir = save_smir
         self.smir = smir
         self.start_symbol = start_symbol
+        self.decode_mode = decode_mode
 
 
 @dataclass

--- a/kmir/src/kmir/ty.py
+++ b/kmir/src/kmir/ty.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, NewType
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from typing import Any, Final
 
 
@@ -60,7 +61,7 @@ class TypeMetadata(ABC):  # noqa: B024
 
         return cls.from_raw(data)
 
-    def nbytes(self, types: dict[Ty, TypeMetadata]) -> int:
+    def nbytes(self, types: Mapping[Ty, TypeMetadata]) -> int:
         raise ValueError(f'Method nbytes() is unsupported for type: {self}')
 
 
@@ -86,7 +87,7 @@ class PrimitiveT(TypeMetadata, ABC):
 
 @dataclass
 class Bool(PrimitiveT):
-    def nbytes(self, types: dict[Ty, TypeMetadata]) -> int:
+    def nbytes(self, types: Mapping[Ty, TypeMetadata]) -> int:
         return 1
 
 
@@ -107,7 +108,7 @@ class Float(PrimitiveT):
 class Int(PrimitiveT):
     info: IntTy
 
-    def nbytes(self, types: dict[Ty, TypeMetadata]) -> int:
+    def nbytes(self, types: Mapping[Ty, TypeMetadata]) -> int:
         return self.info.value
 
 
@@ -115,7 +116,7 @@ class Int(PrimitiveT):
 class Uint(PrimitiveT):
     info: UintTy
 
-    def nbytes(self, types: dict[Ty, TypeMetadata]) -> int:
+    def nbytes(self, types: Mapping[Ty, TypeMetadata]) -> int:
         return self.info.value
 
 
@@ -222,7 +223,7 @@ class ArrayT(TypeMetadata):
             case _:
                 raise _cannot_parse_as('ArrayT', data)
 
-    def nbytes(self, types: dict[Ty, TypeMetadata]) -> int:
+    def nbytes(self, types: Mapping[Ty, TypeMetadata]) -> int:
         if self.length is None:
             raise ValueError(f'Method nbytes() is unsupported for array of unknown length: {self}')
 


### PR DESCRIPTION
Adds a new command-line option, `--decode-mode`, to `prove-rs`. This option controls how allocations are decoded before proving and supports three modes:
* `full`: Decode all allocations during preprocessing. If an allocation cannot be decoded to a `Value`, the result is `UnableToDecode{Value,Alloc}`.
* `partial`: Attempt to decode all allocations during preprocessing. Any allocation that cannot be decoded is deferred to the K interpreter for runtime decoding.
* `none`: Skip preprocessing: do not decode allocations in advance.