### PR TITLE
Enhance kmir show with `--statistics` and `--leaves` (#707)

### DIFF
--- a/kmir/src/kmir/options.py
+++ b/kmir/src/kmir/options.py
@@ -158,6 +158,8 @@ class ShowOpts(DisplayOpts):
     omit_cells: tuple[str, ...] | None
     omit_static_info: bool
     use_default_printer: bool
+    statistics: bool
+    leaves: bool
 
     def __init__(
         self,
@@ -173,10 +175,14 @@ class ShowOpts(DisplayOpts):
         omit_cells: str | None = None,
         omit_static_info: bool = True,
         use_default_printer: bool = False,
+        statistics: bool = False,
+        leaves: bool = False,
     ) -> None:
         super().__init__(proof_dir, id, full_printer, smir_info, omit_current_body)
         self.omit_static_info = omit_static_info
         self.use_default_printer = use_default_printer
+        self.statistics = statistics
+        self.leaves = leaves
         self.nodes = tuple(int(n.strip()) for n in nodes.split(',')) if nodes is not None else None
 
         def _parse_pairs(text: str | None) -> tuple[tuple[int, int], ...] | None:

--- a/kmir/src/kmir/utils.py
+++ b/kmir/src/kmir/utils.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Sequence
 
 if TYPE_CHECKING:
+    from pyk.cterm.show import CTermShow
+    from pyk.kcfg.kcfg import KCFG
     from pyk.proof.reachability import APRProof
 
 
@@ -100,5 +102,144 @@ def render_rules(proof: APRProof, edges: Sequence[tuple[int, int]]) -> list[str]
         for rule in applied:
             lines.append(_rule_to_markdown_link(rule))
             lines.append('-' * 80)
+
+    return lines
+
+
+def render_statistics(proof: APRProof) -> list[str]:
+    """Return human-readable statistics about the proof graph."""
+
+    kcfg = proof.kcfg
+
+    role_nodes: dict[str, list[int]] = {}
+
+    def classify(node_id: int) -> str:
+        if kcfg.is_root(node_id):
+            return 'root'
+        if proof.is_target(node_id):
+            return 'target'
+        if proof.is_terminal(node_id):
+            return 'terminal'
+        if proof.is_refuted(node_id):
+            return 'refuted'
+        if proof.is_bounded(node_id):
+            return 'bounded'
+        if proof.is_pending(node_id):
+            return 'pending'
+        if proof.is_failing(node_id):
+            return 'failing'
+        if kcfg.is_split(node_id) or kcfg.is_ndbranch(node_id):
+            return 'split'
+        if kcfg.is_stuck(node_id):
+            return 'stuck'
+        return 'normal'
+
+    for node in kcfg.nodes:
+        role = classify(node.id)
+        role_nodes.setdefault(role, []).append(node.id)
+
+    root_nodes = role_nodes.pop('root', [])
+    total_nodes = sum(len(ids) for ids in role_nodes.values())
+
+    role_order = (
+        'target',
+        'terminal',
+        'bounded',
+        'refuted',
+        'pending',
+        'failing',
+        'split',
+        'stuck',
+        'normal',
+    )
+
+    lines: list[str] = ['STATISTICS', '-----------', f'Total nodes: {total_nodes}', '', 'Node roles (exclusive):']
+
+    for label in role_order:
+        ids = sorted(role_nodes.get(label, ()))
+        if ids:
+            id_str = ', '.join(str(i) for i in ids)
+            lines.append(f'  {label:8s}: {len(ids)}  ids: {id_str}')
+
+    if root_nodes:
+        lines.append('  (root nodes omitted from totals: ' + ', '.join(str(i) for i in sorted(root_nodes)) + ')')
+
+    lines.append('')
+    lines.append('Leaf paths from init:')
+
+    leaves = [node for node in kcfg.leaves if not kcfg.is_root(node.id)]
+    total_steps = 0
+    reachable_leaf_count = 0
+    leaf_lines: list[str] = []
+
+    def _path_nodes(source_id: int, path: Sequence[KCFG.Successor]) -> list[int]:
+        from pyk.kcfg.kcfg import KCFG as _KCFG
+
+        node_ids = [source_id]
+        current = source_id
+        for succ in path:
+            target_id: int | None = None
+            if isinstance(succ, _KCFG.EdgeLike):
+                target_id = succ.target.id
+            elif isinstance(succ, _KCFG.MultiEdge):
+                targets = list(succ.targets)
+                if len(targets) == 1:
+                    target_id = targets[0].id
+            if target_id is not None and target_id != current:
+                node_ids.append(target_id)
+                current = target_id
+        return node_ids
+
+    for leaf in sorted(leaves, key=lambda n: n.id):
+        path = kcfg.shortest_path_between(proof.init, leaf.id)
+        if path is None:
+            leaf_lines.append(f'  leaf {leaf.id}: unreachable from init')
+            continue
+
+        steps = kcfg.path_length(path)
+        total_steps += steps
+        reachable_leaf_count += 1
+        node_seq = _path_nodes(proof.init, path)
+        seq_str = ' -> '.join(str(nid) for nid in node_seq)
+        leaf_lines.append(f'  leaf {leaf.id}: steps {steps}, path {seq_str}')
+
+    lines.append(f'  total leaves (non-root): {len(leaves)}')
+    lines.append(f'  reachable leaves       : {reachable_leaf_count}')
+    lines.append(f'  total steps            : {total_steps}')
+
+    if leaf_lines:
+        lines.append('')
+        lines.extend(leaf_lines)
+
+    return lines
+
+
+def render_leaf_k_cells(proof: APRProof, cterm_show: CTermShow) -> list[str]:
+    """Render the <k> cell for every leaf node in the proof."""
+
+    leaves = sorted(
+        [node for node in proof.kcfg.leaves if not proof.kcfg.is_root(node.id)],
+        key=lambda node: node.id,
+    )
+    header = ['LEAF <k> CELLS', '---------------']
+    if not leaves:
+        return header + ['  (no leaf nodes)']
+
+    lines: list[str] = header
+    for idx, leaf in enumerate(leaves):
+        lines.append(f'Node {leaf.id}:')
+        try:
+            k_cell = leaf.cterm.cell('K_CELL')
+            k_lines = cterm_show.print_lines(k_cell)
+        except KeyError:
+            k_lines = ['<K_CELL unavailable>']
+
+        if not k_lines:
+            lines.append('  (empty)')
+        else:
+            lines.extend(f'  {k_line}' for k_line in k_lines)
+
+        if idx != len(leaves) - 1:
+            lines.append('')
 
     return lines

--- a/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.main.cli-stats-leaves.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.main.cli-stats-leaves.expected
@@ -1,0 +1,36 @@
+
+┌─ 1 (root, init)
+│   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
+│   span: src/rust/library/std/src/rt.rs:194
+│
+│  (562 steps)
+└─ 3 (stuck, leaf)
+    #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
+    function: main
+    span: prove-rs/symbolic-args-fail.rs:53
+
+
+┌─ 2 (root, leaf, target, terminal)
+│   #EndProgram ~> .K
+
+
+
+STATISTICS
+-----------
+Total nodes: 1
+
+Node roles (exclusive):
+  failing : 1  ids: 3
+  (root nodes omitted from totals: 1, 2)
+
+Leaf paths from init:
+  total leaves (non-root): 1
+  reachable leaves       : 1
+  total steps            : 562
+
+  leaf 3: steps 562, path 1 -> 3
+
+LEAF <k> CELLS
+---------------
+Node 3:
+  #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandConstant ( constOperand ( ... span: span ( 117 ) , userTy: noUserTypeAnnotationIndex , const: mirConst ( ... kind: constantKindZeroSized , ty: ty ( 38 ) , id: mirConstId ( 24 ) ) ) ) , args: operandConstant ( constOperand ( ... span: span ( 32 ) , userTy: noUserTypeAnnotationIndex , const: mirConst ( ... kind: constantKindAllocated ( allocation ( ... bytes: b"\x00\x00\x00\x00\x00\x00\x00\x00\x17\x00\x00\x00\x00\x00\x00\x00" , provenance: provenanceMap ( ... ptrs: provenanceMapEntry ( ... offset: 0 , allocId: allocId ( 1 ) )  .ProvenanceMapEntries ) , align: align ( 8 ) , mutability: mutabilityMut ) ) , ty: ty ( 39 ) , id: mirConstId ( 25 ) ) ) )  .Operands , destination: place ( ... local: local ( 25 ) , projection: .ProjectionElems ) , target: noBasicBlockIdx , unwind: unwindActionContinue ) , span: span ( 117 ) ) ) ~> .K

--- a/kmir/src/tests/integration/test_cli.py
+++ b/kmir/src/tests/integration/test_cli.py
@@ -69,6 +69,33 @@ def test_cli_show_printers_snapshot(
     )
 
 
+def test_cli_show_statistics_and_leaves(
+    kmir: KMIR, tmp_path: Path, capsys: pytest.CaptureFixture[str], update_expected_output: bool
+) -> None:
+    rs_file = PROVE_RS_DIR / 'symbolic-args-fail.rs'
+    start_symbol = 'main'
+    apr_proof = _prove_and_store(kmir, rs_file, tmp_path, start_symbol=start_symbol, is_smir=False)
+
+    show_opts = ShowOpts(
+        proof_dir=tmp_path,
+        id=apr_proof.id,
+        full_printer=False,
+        smir_info=None,
+        omit_current_body=False,
+        use_default_printer=False,
+        statistics=True,
+        leaves=True,
+    )
+    _kmir_show(show_opts)
+    out = capsys.readouterr().out.rstrip()
+
+    assert_or_update_show_output(
+        out,
+        PROVE_RS_DIR / f'show/{rs_file.stem}.{start_symbol}.cli-stats-leaves.expected',
+        update=update_expected_output,
+    )
+
+
 def test_cli_info_snapshot(capsys: pytest.CaptureFixture[str], update_expected_output: bool) -> None:
     smir_json = PROVE_RS_DIR / 'arith.smir.json'
     smir_info = SMIRInfo.from_file(smir_json)


### PR DESCRIPTION
It is used to print better `proof_status.md` for solana-token, aiming to include all the information useful to fast investigate the result and update `tests.md`.

Example output with `--statistics` and `--leaves`:

```
STATISTICS
-----------
Total nodes: 10

Node roles (exclusive):
  failing : 2  ids: 10, 12
  split   : 1  ids: 6
  normal  : 7  ids: 3, 4, 5, 7, 8, 9, 11
  (root nodes omitted from totals: 1, 2)

Leaf paths from init:
  total leaves (non-root): 2
  reachable leaves       : 2
  total steps            : 2193

  leaf 10: steps 893, path 1 -> 3 -> 4 -> 5 -> 6 -> 8 -> 10
  leaf 12: steps 1300, path 1 -> 3 -> 4 -> 5 -> 6 -> 7 -> 9 -> 11 -> 12

LEAF <k> CELLS
---------------
Node 10:
  #traverseProjection ( toLocal ( 2 ) , AllocRef ( allocId ( 600719 ) , .ProjectionElems , noMetadata ) , projectionElemDeref  .ProjectionElems , .Contexts )
  ~> #readProjection ( false )
  ~> #freezer#discriminant(_,_)_RT-DATA_Evaluation_Evaluation_MaybeTy0_ ( ty ( 600110 ) ~> .K )
  ~> #freezer#setLocalValue(_,_)_RT-DATA_KItem_Place_Evaluation1_ ( place ( ... local: local ( 4 ) , projection: .ProjectionElems ) ~> .K )
  ~> #execStmts ( statement ( ... kind: statementKindAssign ( ... place: place ( ... local: local ( 0 ) , projection: .ProjectionElems ) , rvalue: rvalueBinaryOp ( binOpEq , operandCopy ( place ( ... local: local ( 3 ) , projection: .ProjectionElems ) ) , operandCopy ( place ( ... local: local ( 4 ) , projection: .ProjectionElems ) ) ) ) , span: span ( 621308 ) )  .Statements )
  ~> #execTerminator ( terminator ( ... kind: terminatorKindReturn , span: span ( 621307 ) ) )

Node 12:
  #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandConstant ( constOperand ( ... span: span ( 603598 ) , userTy: noUserTypeAnnotationIndex , const: mirConst ( ... kind: constantKindZeroSized , ty: ty ( 600118 ) , id: mirConstId ( 39 ) ) ) ) , args: operandConstant ( constOperand ( ... span: span ( 603599 ) , userTy: noUserTypeAnnotationIndex , const: mirConst ( ... kind: constantKindAllocated ( allocation ( ... bytes: b"\x00\x00\x00\x00\x00\x00\x00\x00+\x00\x00\x00\x00\x00\x00\x00" , provenance: provenanceMap ( ... ptrs: provenanceMapEntry ( ... offset: 0 , allocId: allocId ( 600074 ) )  .ProvenanceMapEntries ) , align: align ( 8 ) , mutability: mutabilityMut ) ) , ty: ty ( 600073 ) , id: mirConstId ( 474 ) ) ) )  operandMove ( place ( ... local: local ( 5 ) , projection: .ProjectionElems ) )  .Operands , destination: place ( ... local: local ( 4 ) , projection: .ProjectionElems ) , target: noBasicBlockIdx , unwind: unwindActionCleanup ( basicBlockIdx ( 4 ) ) ) , span: span ( 603600 ) ) ) ~> .K
```

(cherry picked from commit 4a6892b8b52416368cd3e308a98ac1cfc9c3ccd2)