### PR TITLE
replace interim-simplification 50 by simplify-each 30

### DIFF
--- a/kmir/src/kmir/kmir.py
+++ b/kmir/src/kmir/kmir.py
@@ -83,7 +83,7 @@ class KMIR(KProve, KRun, KParse):
             llvm_definition_dir=self.llvm_library_dir,
             bug_report=self.bug_report,
             id=label if self.bug_report is not None else None,  # NB bug report arg.s must be coherent
-            interim_simplification=50,  # working around memory problems in LLVM backend calls
+            simplify_each=30,
         ) as cts:
             yield KCFGExplore(cts, kcfg_semantics=KMIRSemantics())
 


### PR DESCRIPTION
The `--simplify-each` option only affects booster execution while `--interim-simplification` forces a fall-back to `kore` which is more expensive.