### PR TITLE
fix(rt): add fallback for zero-sized constants in operand decoding

### DIFF
--- a/kmir/src/kmir/kdist/mir-semantics/rt/data.md
+++ b/kmir/src/kmir/kdist/mir-semantics/rt/data.md
@@ -128,6 +128,13 @@ Constant operands are simply decoded according to their type.
        ...
        </k>
     requires typeInfoVoidType =/=K lookupTy(TY)
+
+  // Fallback for zero-sized constants whose type metadata was not emitted.
+  rule <k> operandConstant(constOperand(_, _, mirConst(constantKindZeroSized, TY, _)))
+        => Aggregate(variantIdx(0), .List)
+       ...
+       </k>
+    requires typeInfoVoidType ==K lookupTy(TY) 
 ```
 
 ### Copying and Moving


### PR DESCRIPTION
Need to investigate more after other changes merged.