### PR TITLE
add simplification to remove `#mapOffset` from symbolic key bytes lists

### DIFF
--- a/kmir/src/kmir/kdist/mir-semantics/symbolic/p-token.md
+++ b/kmir/src/kmir/kdist/mir-semantics/symbolic/p-token.md
@@ -115,6 +115,15 @@ The code uses some helper sorts for better readability.
   // We assume that the Key always contains valid data, because it is constructed via toKey.
   rule fromKey(KeyError(VAL)) => VAL
   rule fromKey(Key(VAL))      => Range(VAL) [preserves-definedness]
+```
+For lists that are already known to contain bytes, the following simplification removes the `#mapOffset` call
+This ensures that branches on the key value are not duplicated.
+
+```k
+  rule #mapOffset(VAR, _) => VAR requires allBytes(VAR)
+```
+
+```k
 
   syntax Signers ::= Signers ( List ) // 11 Pubkeys, each List of 32 bytes
                    | SignersError ( Value )


### PR DESCRIPTION
`#mapOffset` adjusts the offset parameter of references and pointers in argument lists when values containing them are read from or written to outer stack frames. This happens to the bytes of `PubKey` data in P-token, which is known to be all `Integer(_, 8, false)` but abstracted in a list-sorted variable.
Without this simplification, a path condition `KEYBYTES ==K <some key>` will not imply `#mapOffset(KEYBYTES) ==K <some key>`. This was causing vacuous branches which end up in `assert_failed` calls.
Some proofs were failing before and are passing with this simplification. 