### PR TITLE
Special fix-up rule to apply field projection on array head elements

### DIFF
--- a/kmir/src/kmir/kdist/mir-semantics/rt/data.md
+++ b/kmir/src/kmir/kdist/mir-semantics/rt/data.md
@@ -469,6 +469,21 @@ The context is populated with the correct field access data, so that write-backs
     [preserves-definedness, priority(100)]
 ```
 
+A somewhat dual case to this rule can occur when a pointer into an array of data elements has been offset and is then dereferenced.
+The dereferenced pointer may either point to a subslice or to a single element (depending on context).
+Therefore, a field projection may be found which has to be applied to the head element of an array.
+The following rule resolves this situation by using the head element.
+
+```k
+  rule <k> #traverseProjection(
+             DEST,
+             Range(ListItem(Aggregate(_, _) #as VALUE) _REST:List),
+             projectionElemField(IDX, TY) PROJS,
+             CTXTS
+           )
+        => #traverseProjection(DEST, VALUE, projectionElemField(IDX, TY) PROJS, CTXTS) ... </k> // TODO mark context?
+    [preserves-definedness, priority(100)]
+```
 
 #### Unions
 ```k


### PR DESCRIPTION
When using pointer offsets followed by dereferencing, the returned result is an array (subslice of the original).
In some cases, the value is used as a single element, for instance by projecting out a field. This PR adds a special rule for the field projection case to proceed using the head element in those cases.

Related: #771 