### PR TITLE
fix: include function pointer arguments in call_edges for reduce_to

### DIFF
--- a/kmir/src/tests/integration/data/prove-rs/488-support-function-pointer-calls.rs
+++ b/kmir/src/tests/integration/data/prove-rs/488-support-function-pointer-calls.rs
@@ -20,7 +20,6 @@ impl TryFrom<&[u8]> for EightBytes {
 
 fn main() {
     let bytes: [u8;8] = [1,2,3,4,5,6,7,8];
-    let _unused = EightBytes::from(bytes);
     let slice: &[u8] = &bytes;
     let thing: Result<EightBytes, _> = EightBytes::try_from(slice);
     assert!(thing.is_ok());


### PR DESCRIPTION
The call_edges method now collects both:
1. Direct calls: functions used as the func operand in Call terminators
2. Indirect calls: functions passed as arguments (ZeroSized constants) that may be called via function pointers

This fixes the 'unknown function' issue when a function is passed as an argument to higher-order functions like Result::map.