### PR TITLE
Handled additional Range constructor in toSigners side condition.

### DIFF
--- a/kmir/src/kmir/kdist/mir-semantics/symbolic/p-token.md
+++ b/kmir/src/kmir/kdist/mir-semantics/symbolic/p-token.md
@@ -130,7 +130,7 @@ This ensures that branches on the key value are not duplicated.
 
   syntax Signers ::= toSigners ( Value ) [function, total]
   // -----------------------------------------------------
-  rule toSigners(Range(ELEMS)) => Signers( toKeys(ELEMS) ) requires size(ELEMS) ==Int 11 andBool allKeys(ELEMS)
+  rule toSigners(Range(ELEMS)) => Signers( toKeys(ELEMS) ) requires size(ELEMS) ==Int 11 andBool allRangeWrappedKeys(ELEMS)
   rule toSigners(VAL) => SignersError(VAL) [owise]
 
   syntax Value ::= fromSigners ( Signers ) [function, total]
@@ -155,6 +155,12 @@ This ensures that branches on the key value are not duplicated.
   rule allKeys( .List ) => true
   rule allKeys( ListItem(ELEMS) REST:List ) => allKeys(REST) requires size(ELEMS) ==Int 32 andBool allBytes(ELEMS)
   rule allKeys( ListItem(_OTHER) _:List )   => false [owise]
+
+  syntax Bool ::= allRangeWrappedKeys ( List ) [function, total]
+  // -----------------------------------------------------------
+  rule allRangeWrappedKeys( .List ) => true
+  rule allRangeWrappedKeys( ListItem(Range(ELEMS)) REST:List ) => allRangeWrappedKeys(REST) requires size(ELEMS) ==Int 32 andBool allBytes(ELEMS)
+  rule allRangeWrappedKeys( ListItem(_OTHER) _:List )   => false [owise]
 ```
 
 ### SPL Token Interface Account


### PR DESCRIPTION
This PR replaces the `allKeys` condition in the requires clause of `toSigners` with another function, `allRangeWrappedKeys`, that works in exactly the same way except is unwraps an additional Range constructor from the provided `ListItem`. This `Range` is generated from `fromKey`, and the existing `allKeys` implementation was not sufficient to handle it, as it was expecting just a List.

The issue came up when investigating the failure of the proof for test_process_initialize_multisig2. I attach a file that contains a part of the stuck configuration, where I isolated a term that shows the issue. The relevant term is `SignersError(...)`. With this change, the proof was able to pass.
[signers-error.txt](https://github.com/user-attachments/files/25424362/signers-error.txt)

Note: I chose to use a new function rather than extend the functionality of `allKeys` beyond its (apparent) intend to handle Lists, but I believe that the issue could be solved with just another rule in `allKeys`, if that is what you prefer.