### PR TITLE
Attempt to fix master push job by checkout and merge

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -37,13 +37,25 @@ jobs:
           prior_version=$(cat package/version)
           old_master="$(git merge-base origin/master origin/release)"
           new_master="$(git rev-parse origin/master)"
+
+          resolve_submodule_conflicts {
+            git checkout origin/master -- deps/stable-mir-json
+            difference=$(git diff --name-only --diff-filter=U)
+            if [ -m "$difference" ]; then
+              echo "Unresolved merge conflicts remain:"
+              echo "$difference"
+              exit 1
+            fi
+            GIT_EDITOR=true git merge --continue
+          }
+
           # otherwise bump the prior_version
           if git diff --exit-code ${old_master} ${new_master} -- package/version; then
-              git merge --no-edit origin/master
+              git merge --no-edit origin/master || resolve_submodule_conflicts
               package/version.sh bump ${prior_version}
           else
               # if the version has changed on master, use it unmodified
-              git merge --no-edit --strategy-option=theirs origin/master
+              git merge --no-edit --strategy-option=theirs origin/master || resolve_submodule_conflicts
           fi
           # substitute the version in all relevant files
           package/version.sh sub


### PR DESCRIPTION
The release job on [master-push is failing](https://github.com/runtimeverification/mir-semantics/actions/runs/22258160774/job/64641384842), and it seems that the submodule for stable-mir-json is out of sync. This stuff is largely a mystery to me, but I think we just want to check out the `master` version that just got merged. Claude helped write this for full disclosure