### PR TITLE
Makefile `stable-mir-json` command to build release also

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ test: test-unit test-integration smir-parse-tests
 stable-mir-json: CARGO_BUILD_OPTS =
 stable-mir-json:
 	cd deps/stable-mir-json && cargo build ${CARGO_BUILD_OPTS}
+	cd deps/stable-mir-json && cargo build --release ${CARGO_BUILD_OPTS}
 	cd deps/stable-mir-json && cargo run --bin cargo_stable_mir_json -- ${TOP_DIR}/deps/stable-mir-json ${TOP_DIR}/deps
 	${TOP_DIR}/deps/.stable-mir-json/release.sh --version || ${TOP_DIR}/deps/.stable-mir-json/debug.sh --version
 


### PR DESCRIPTION
Stops error where test runner was reading from a stale release