### PR TITLE
fix(symbolic-spl): add sol_memset cut-point for SPLDataBuffer

### DIFF
--- a/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
+++ b/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
@@ -719,25 +719,7 @@ zeroed representation.
       <locals> LOCALS </locals>
     </currentFrame>
     <stack> STACK => ListItem(StackFrame(OLDCALLER, OLDDEST, OLDTARGET, OLDUNWIND, LOCALS)) STACK </stack>
-    requires notBool isIntrinsicFunction(FUNC)
-     andBool notBool #functionNameMatchesEnv(getFunctionName(FUNC))
-
-  rule [spl-sol-memset-fallback-filter]:
-    <k> #execSPLSolMemset(FTY, FUNC, _BUF, _VAL, _LEN, _BUFOP, ARGS, DEST, TARGET, UNWIND, SPAN) ~> _
-      => #setUpCalleeData(FUNC, ARGS, SPAN)
-    </k>
-    <currentFunc> CALLER => FTY </currentFunc>
-    <currentFrame>
-      <currentBody> _ </currentBody>
-      <caller> OLDCALLER => CALLER </caller>
-      <dest> OLDDEST => DEST </dest>
-      <target> OLDTARGET => TARGET </target>
-      <unwind> OLDUNWIND => UNWIND </unwind>
-      <locals> LOCALS </locals>
-    </currentFrame>
-    <stack> STACK => ListItem(StackFrame(OLDCALLER, OLDDEST, OLDTARGET, OLDUNWIND, LOCALS)) STACK </stack>
-    requires notBool isIntrinsicFunction(FUNC)
-     andBool #functionNameMatchesEnv(getFunctionName(FUNC))
+    [owise]
 ```
 
 ## Rent sysvar handling

--- a/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
+++ b/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
@@ -107,6 +107,10 @@ module KMIR-SPL-TOKEN
   syntax Bool ::= #isSplPubkey ( List ) [function, total]
   rule #isSplPubkey(KEY) => size(KEY) ==Int 32 andBool allBytes(KEY)
 
+  syntax Bool ::= #isZeroMemsetValue ( Value ) [function, total]
+  rule #isZeroMemsetValue(Integer(0, _, _)) => true
+  rule #isZeroMemsetValue(_) => false [owise]
+
   // Construct a 32-byte pubkey List from individual Int variables.
   // When used with existential variables (?Var:Int), this produces a concrete List structure
   // that ==K can decompose element-wise, avoiding opaque symbolic List equality in SMT.
@@ -258,6 +262,69 @@ module KMIR-SPL-TOKEN
        )
        => dynamicSize(99)
        [priority(30)]
+
+  syntax Int ::= #splBufferLen ( Value ) [function, total]
+
+  rule #splBufferLen(
+         SPLDataBuffer(
+         Aggregate(variantIdx(0),
+           ListItem(Aggregate(variantIdx(0), ListItem(Range(_))))
+           ListItem(Aggregate(variantIdx(0), ListItem(Range(_))))
+           ListItem(Integer(_, 64, false))
+           ListItem(_DELEG)
+           ListItem(STATE)
+           ListItem(_IS_NATIVE)
+           ListItem(Integer(_, 64, false))
+           ListItem(_CLOSE)
+         )
+       )
+      )
+       => 165
+       requires #isSplAccountStateVal(STATE)
+       [priority(30)]
+
+  rule #splBufferLen(
+         SPLDataBuffer(
+           Aggregate(variantIdx(0),
+             ListItem(_AUTH)
+             ListItem(Integer(_, 64, false))
+             ListItem(Integer(_, 8, false))
+             ListItem(BoolVal(_))
+             ListItem(_FREEZE)
+           )
+         )
+       )
+       => 82
+       [priority(30)]
+
+  rule #splBufferLen(
+         SPLDataBuffer(
+           Aggregate(variantIdx(0),
+             ListItem(Integer(_, 64, false))
+             ListItem(Float(2.0, 64))
+             ListItem(Integer(_, 8, false))
+           )
+         )
+       )
+       => 17
+       [priority(30)]
+
+  rule #splBufferLen(
+         SPLDataBuffer(
+           Aggregate(variantIdx(0),
+             ListItem(Integer(_, 8, false))
+             ListItem(Integer(_, 8, false))
+             ListItem(BoolVal(_))
+             ListItem(Range(
+               ListItem(_) ListItem(_) ListItem(_)
+             ))
+           )
+         )
+       )
+       => 99
+       [priority(30)]
+
+  rule #splBufferLen(_) => 0 [owise]
 ```
 
 ## Cheatcode handling
@@ -617,19 +684,25 @@ zeroed representation.
   // sol_memset(buf, val, len) - intercept when target is SPLDataBuffer
   rule [spl-sol-memset]:
     <k> #execTerminatorCall(_, FUNC,
-          BUF:Operand _VAL:Operand _LEN:Operand .Operands,
+          BUF:Operand VAL:Operand LEN:Operand .Operands,
           _DEST, TARGET, _UNWIND, _SPAN) ~> _CONT
-      => #splSolMemset(#withDeref(BUF), BUF) ~> #continueAt(TARGET)
+      => #splSolMemset(#withDeref(BUF), #withDeref(VAL), #withDeref(LEN), BUF) ~> #continueAt(TARGET)
     </k>
     requires #isSPLSolMemsetFunc(#functionName(FUNC))
     [priority(30), preserves-definedness]
 
-  syntax KItem ::= #splSolMemset ( Evaluation , Operand ) [seqstrict(1)]
+  syntax KItem ::= #splSolMemset ( Evaluation , Evaluation , Evaluation , Operand ) [seqstrict(1,2,3)]
 
-  rule <k> #splSolMemset(SPLDataBuffer(_), operandCopy(DEST))
+  rule <k> #splSolMemset(SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandCopy(DEST))
         => #setLocalValue(DEST, SPLDataBuffer(Integer(0, 8, false))) ... </k>
-  rule <k> #splSolMemset(SPLDataBuffer(_), operandMove(DEST))
+    requires #isZeroMemsetValue(VAL)
+     andBool LEN ==Int #splBufferLen(BUF)
+     andBool 0 <Int #splBufferLen(BUF)
+  rule <k> #splSolMemset(SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandMove(DEST))
         => #setLocalValue(DEST, SPLDataBuffer(Integer(0, 8, false))) ... </k>
+    requires #isZeroMemsetValue(VAL)
+     andBool LEN ==Int #splBufferLen(BUF)
+     andBool 0 <Int #splBufferLen(BUF)
 ```
 
 ## Rent sysvar handling

--- a/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
+++ b/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
@@ -681,28 +681,77 @@ intercept the call and directly replace the `SPLDataBuffer` content with a
 zeroed representation.
 
 ```{.k .symbolic}
-  // sol_memset(buf, val, len) - intercept when target is SPLDataBuffer
+  // sol_memset(buf, val, len) - fast-path full-buffer zeroization on recognized SPLDataBuffer values.
+  // Any other call shape falls back to the ordinary call semantics below.
   rule [spl-sol-memset]:
-    <k> #execTerminatorCall(_, FUNC,
+    <k> #execTerminatorCall(FTY, FUNC,
           BUF:Operand VAL:Operand LEN:Operand .Operands,
-          _DEST, TARGET, _UNWIND, _SPAN) ~> _CONT
-      => #splSolMemset(#withDeref(BUF), #withDeref(VAL), #withDeref(LEN), BUF) ~> #continueAt(TARGET)
+          DEST, TARGET, UNWIND, SPAN) ~> _CONT
+      => #execSPLSolMemset(FTY, FUNC, #withDeref(BUF), VAL, LEN, BUF, BUF VAL LEN .Operands, DEST, TARGET, UNWIND, SPAN)
     </k>
     requires #isSPLSolMemsetFunc(#functionName(FUNC))
     [priority(30), preserves-definedness]
 
-  syntax KItem ::= #splSolMemset ( Evaluation , Evaluation , Evaluation , Operand ) [seqstrict(1,2,3)]
+  syntax KItem ::= #execSPLSolMemset ( Ty, MonoItemKind, Evaluation , Evaluation , Evaluation , Operand, Operands, Place, MaybeBasicBlockIdx, UnwindAction, Span ) [seqstrict(3,4,5)]
 
-  rule <k> #splSolMemset(SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandCopy(DEST))
-        => #setLocalValue(DEST, SPLDataBuffer(Integer(0, 8, false))) ... </k>
+  rule <k> #execSPLSolMemset(_, _, SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandCopy(DESTBUF), _ARGS, _DEST, TARGET, _UNWIND, _SPAN)
+        => #setLocalValue(DESTBUF, SPLDataBuffer(Integer(0, 8, false))) ~> #continueAt(TARGET) ... </k>
     requires #isZeroMemsetValue(VAL)
      andBool LEN ==Int #splBufferLen(BUF)
      andBool 0 <Int #splBufferLen(BUF)
-  rule <k> #splSolMemset(SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandMove(DEST))
-        => #setLocalValue(DEST, SPLDataBuffer(Integer(0, 8, false))) ... </k>
+  rule <k> #execSPLSolMemset(_, _, SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandMove(DESTBUF), _ARGS, _DEST, TARGET, _UNWIND, _SPAN)
+        => #setLocalValue(DESTBUF, SPLDataBuffer(Integer(0, 8, false))) ~> #continueAt(TARGET) ... </k>
     requires #isZeroMemsetValue(VAL)
      andBool LEN ==Int #splBufferLen(BUF)
      andBool 0 <Int #splBufferLen(BUF)
+
+  rule [spl-sol-memset-fallback-intrinsic]:
+    <k> #execSPLSolMemset(_, FUNC, _BUF, _VAL, _LEN, _BUFOP, ARGS, DEST, TARGET, _UNWIND, SPAN) ~> _
+      => #execIntrinsic(FUNC, ARGS, DEST, SPAN) ~> #continueAt(TARGET)
+    </k>
+    requires isIntrinsicFunction(FUNC)
+     andBool notBool #functionNameMatchesEnv(getFunctionName(FUNC))
+
+  rule [spl-sol-memset-fallback-intrinsic-filter]:
+    <k> #execSPLSolMemset(_, FUNC, _BUF, _VAL, _LEN, _BUFOP, ARGS, DEST, TARGET, _UNWIND, SPAN) ~> _
+      => #execIntrinsic(FUNC, ARGS, DEST, SPAN) ~> #continueAt(TARGET)
+    </k>
+    requires isIntrinsicFunction(FUNC)
+     andBool #functionNameMatchesEnv(getFunctionName(FUNC))
+
+  rule [spl-sol-memset-fallback]:
+    <k> #execSPLSolMemset(FTY, FUNC, _BUF, _VAL, _LEN, _BUFOP, ARGS, DEST, TARGET, UNWIND, SPAN) ~> _
+      => #setUpCalleeData(FUNC, ARGS, SPAN)
+    </k>
+    <currentFunc> CALLER => FTY </currentFunc>
+    <currentFrame>
+      <currentBody> _ </currentBody>
+      <caller> OLDCALLER => CALLER </caller>
+      <dest> OLDDEST => DEST </dest>
+      <target> OLDTARGET => TARGET </target>
+      <unwind> OLDUNWIND => UNWIND </unwind>
+      <locals> LOCALS </locals>
+    </currentFrame>
+    <stack> STACK => ListItem(StackFrame(OLDCALLER, OLDDEST, OLDTARGET, OLDUNWIND, LOCALS)) STACK </stack>
+    requires notBool isIntrinsicFunction(FUNC)
+     andBool notBool #functionNameMatchesEnv(getFunctionName(FUNC))
+
+  rule [spl-sol-memset-fallback-filter]:
+    <k> #execSPLSolMemset(FTY, FUNC, _BUF, _VAL, _LEN, _BUFOP, ARGS, DEST, TARGET, UNWIND, SPAN) ~> _
+      => #setUpCalleeData(FUNC, ARGS, SPAN)
+    </k>
+    <currentFunc> CALLER => FTY </currentFunc>
+    <currentFrame>
+      <currentBody> _ </currentBody>
+      <caller> OLDCALLER => CALLER </caller>
+      <dest> OLDDEST => DEST </dest>
+      <target> OLDTARGET => TARGET </target>
+      <unwind> OLDUNWIND => UNWIND </unwind>
+      <locals> LOCALS </locals>
+    </currentFrame>
+    <stack> STACK => ListItem(StackFrame(OLDCALLER, OLDDEST, OLDTARGET, OLDUNWIND, LOCALS)) STACK </stack>
+    requires notBool isIntrinsicFunction(FUNC)
+     andBool #functionNameMatchesEnv(getFunctionName(FUNC))
 ```
 
 ## Rent sysvar handling

--- a/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
+++ b/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
@@ -183,6 +183,10 @@ module KMIR-SPL-TOKEN
   rule #isSPLRentGetFunc(_) => false [owise]
   rule #isSPLRentGetFunc("Rent::get") => true   // mock harness
   rule #isSPLRentGetFunc("solana_sysvar::rent::<impl Sysvar for solana_rent::Rent>::get") => true
+
+  syntax Bool ::= #isSPLSolMemsetFunc ( String ) [function, total]
+  rule #isSPLSolMemsetFunc(_) => false [owise]
+  rule #isSPLSolMemsetFunc("solana_program_memory::sol_memset") => true
 ```
 
 ## Slice metadata for SPL account buffers
@@ -600,6 +604,32 @@ The `#initBorrow` helper resets borrow counters to 0 and sets the correct dynami
   syntax KItem ::= #splPack ( Evaluation , Operand ) [seqstrict(1)]
   rule <k> #splPack(VAL, operandCopy(DEST)) => #setLocalValue(DEST, SPLDataBuffer(VAL)) ... </k>
   rule <k> #splPack(VAL, operandMove(DEST)) => #setLocalValue(DEST, SPLDataBuffer(VAL)) ... </k>
+```
+
+## sol_memset on SPL data buffers
+
+`sol_memset` is used by `delete_account` to zero out account data. Rather than
+symbolically executing the byte-by-byte loop through `IterMut::next`, we
+intercept the call and directly replace the `SPLDataBuffer` content with a
+zeroed representation.
+
+```{.k .symbolic}
+  // sol_memset(buf, val, len) - intercept when target is SPLDataBuffer
+  rule [spl-sol-memset]:
+    <k> #execTerminatorCall(_, FUNC,
+          BUF:Operand _VAL:Operand _LEN:Operand .Operands,
+          _DEST, TARGET, _UNWIND, _SPAN) ~> _CONT
+      => #splSolMemset(#withDeref(BUF), BUF) ~> #continueAt(TARGET)
+    </k>
+    requires #isSPLSolMemsetFunc(#functionName(FUNC))
+    [priority(30), preserves-definedness]
+
+  syntax KItem ::= #splSolMemset ( Evaluation , Operand ) [seqstrict(1)]
+
+  rule <k> #splSolMemset(SPLDataBuffer(_), operandCopy(DEST))
+        => #setLocalValue(DEST, SPLDataBuffer(Integer(0, 8, false))) ... </k>
+  rule <k> #splSolMemset(SPLDataBuffer(_), operandMove(DEST))
+        => #setLocalValue(DEST, SPLDataBuffer(Integer(0, 8, false))) ... </k>
 ```
 
 ## Rent sysvar handling

--- a/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
+++ b/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
@@ -321,7 +321,7 @@ module KMIR-SPL-TOKEN
            )
          )
        )
-       => 99
+       => 99 // Multisig layout: m (1) + n (1) + is_initialized (1) + 3 * 32 signer bytes (MAX_SIGNERS = 3)
        [priority(30)]
 
   rule #splBufferLen(_) => 0 [owise]
@@ -704,20 +704,6 @@ zeroed representation.
     requires #isZeroMemsetValue(VAL)
      andBool LEN ==Int #splBufferLen(BUF)
      andBool 0 <Int #splBufferLen(BUF)
-
-  rule [spl-sol-memset-fallback-intrinsic]:
-    <k> #execSPLSolMemset(_, FUNC, _BUF, _VAL, _LEN, _BUFOP, ARGS, DEST, TARGET, _UNWIND, SPAN) ~> _
-      => #execIntrinsic(FUNC, ARGS, DEST, SPAN) ~> #continueAt(TARGET)
-    </k>
-    requires isIntrinsicFunction(FUNC)
-     andBool notBool #functionNameMatchesEnv(getFunctionName(FUNC))
-
-  rule [spl-sol-memset-fallback-intrinsic-filter]:
-    <k> #execSPLSolMemset(_, FUNC, _BUF, _VAL, _LEN, _BUFOP, ARGS, DEST, TARGET, _UNWIND, SPAN) ~> _
-      => #execIntrinsic(FUNC, ARGS, DEST, SPAN) ~> #continueAt(TARGET)
-    </k>
-    requires isIntrinsicFunction(FUNC)
-     andBool #functionNameMatchesEnv(getFunctionName(FUNC))
 
   rule [spl-sol-memset-fallback]:
     <k> #execSPLSolMemset(FTY, FUNC, _BUF, _VAL, _LEN, _BUFOP, ARGS, DEST, TARGET, UNWIND, SPAN) ~> _

--- a/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
+++ b/kmir/src/kmir/kdist/mir-semantics/symbolic/spl-token.md
@@ -694,13 +694,13 @@ zeroed representation.
 
   syntax KItem ::= #execSPLSolMemset ( Ty, MonoItemKind, Evaluation , Evaluation , Evaluation , Operand, Operands, Place, MaybeBasicBlockIdx, UnwindAction, Span ) [seqstrict(3,4,5)]
 
-  rule <k> #execSPLSolMemset(_, _, SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandCopy(DESTBUF), _ARGS, _DEST, TARGET, _UNWIND, _SPAN)
-        => #setLocalValue(DESTBUF, SPLDataBuffer(Integer(0, 8, false))) ~> #continueAt(TARGET) ... </k>
+  rule <k> #execSPLSolMemset(_, _, SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandCopy(place(LOCAL, PROJS)), _ARGS, _DEST, TARGET, _UNWIND, _SPAN)
+        => #setLocalValue(place(LOCAL, appendP(PROJS, projectionElemDeref .ProjectionElems)), SPLDataBuffer(Integer(0, 8, false))) ~> #continueAt(TARGET) ... </k>
     requires #isZeroMemsetValue(VAL)
      andBool LEN ==Int #splBufferLen(BUF)
      andBool 0 <Int #splBufferLen(BUF)
-  rule <k> #execSPLSolMemset(_, _, SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandMove(DESTBUF), _ARGS, _DEST, TARGET, _UNWIND, _SPAN)
-        => #setLocalValue(DESTBUF, SPLDataBuffer(Integer(0, 8, false))) ~> #continueAt(TARGET) ... </k>
+  rule <k> #execSPLSolMemset(_, _, SPLDataBuffer(_) #as BUF, VAL, Integer(LEN, 64, false), operandMove(place(LOCAL, PROJS)), _ARGS, _DEST, TARGET, _UNWIND, _SPAN)
+        => #setLocalValue(place(LOCAL, appendP(PROJS, projectionElemDeref .ProjectionElems)), SPLDataBuffer(Integer(0, 8, false))) ~> #continueAt(TARGET) ... </k>
     requires #isZeroMemsetValue(VAL)
      andBool LEN ==Int #splBufferLen(BUF)
      andBool 0 <Int #splBufferLen(BUF)


### PR DESCRIPTION
## Summary
- Add a symbolic cut-point for `solana_program_memory::sol_memset`
- When the target is an `SPLDataBuffer`, model the call by writing back a zeroed buffer directly

## Stack
This PR is stacked on #1007 (`sync-pr1006`). The earlier `#forceSetLocal` cleanup is already in the base branch and is not part of this diff.

## Why
`close_account` eventually calls `sol_memset(*account_data, 0, data_len)` to clear SPL account data.
Without a cut-point, the prover follows the byte-by-byte iterator path and gets stuck in `#traverseProjection` while indexing through the internal `SPLDataBuffer` aggregate.

## Change
Intercept `sol_memset` in the symbolic SPL layer and replace `SPLDataBuffer(_)` with `SPLDataBuffer(Integer(0, 8, false))` directly.

## Validation
- `make build`
- `test_process_close_account_multisig` passes with `n == 1`
  - `PASSED`
  - 355 nodes, 0 stuck, 0 pending, 90 terminal