### PR TITLE
ci: install nix on MacM1 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,6 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        if: ${{ matrix.runner != 'MacM1' }}
         uses: cachix/install-nix-action@v31.5.1
         with:
           install_url: https://releases.nixos.org/nix/nix-2.31.2/install
@@ -229,7 +228,6 @@ jobs:
             trusted-public-keys = cache.nixos.org
 
       - name: 'Install Cachix'
-        if: ${{ matrix.runner != 'MacM1' }}
         uses: cachix/cachix-action@v16
         with:
           name: k-framework
@@ -239,4 +237,3 @@ jobs:
           set -euxo pipefail
           nix --version
           nix flake check # build and run smoke test
-


### PR DESCRIPTION
## Summary
- run the existing Nix setup steps on `MacM1` runners instead of skipping them
- keep the `nix` job logic identical across `normal` and `MacM1` so `nix --version` and `nix flake check` run against an initialized environment

## Why
The current workflow skips `Install Nix` and `Install Cachix` on `MacM1`, but the following `Build and test` step still runs `nix --version` and `nix flake check`. That makes the MacM1 job fail before it can exercise the actual repository checks.

## Validation
- workflow diff reviewed against `master`
- no repository code paths changed; only the Nix job setup conditions were removed