### PR TITLE
fix(pointer-casts): support array-to-wrapper projections

### DIFF
--- a/kmir/src/kmir/kdist/mir-semantics/rt/data.md
+++ b/kmir/src/kmir/kdist/mir-semantics/rt/data.md
@@ -492,6 +492,20 @@ The situation typically arises when the stored value is a pointer (`NonNull`) bu
            )
         => #traverseProjection(DEST, Aggregate(variantIdx(0), ListItem(VALUE)), PROJS, CtxWrapStruct CTXTS) ... </k>
     [preserves-definedness, priority(100)]
+
+  rule <k> #traverseProjection(
+             DEST,
+             Aggregate(variantIdx(0), ListItem(Range(ELEMS))),
+             projectionElemConstantIndex(I, MIN_LENGTH, FROM_END) PROJS,
+             CTXTS
+           )
+        => #traverseProjection(
+             DEST,
+             Range(ELEMS),
+             projectionElemConstantIndex(I, MIN_LENGTH, FROM_END) PROJS,
+             CTXTS
+           ) ... </k>
+    [preserves-definedness, priority(100)]
 ```
 
 A somewhat dual case to this rule can occur when a pointer into an array of data elements has been offset and is then dereferenced.

--- a/kmir/src/kmir/kdist/mir-semantics/rt/types.md
+++ b/kmir/src/kmir/kdist/mir-semantics/rt/types.md
@@ -113,10 +113,11 @@ the source should be wrapped rather than unwrapped (e.g., `*const [u8;2] → *co
         )
     requires #zeroFieldOffset(LAYOUT)
 
-  rule #pointeeProjection(SRC:TypeInfo, typeInfoStructType(NAME, ADTDEF, FIELD .Tys, LAYOUT))
-    => #pointeeProjectionTarget(SRC, typeInfoStructType(NAME, ADTDEF, FIELD .Tys, LAYOUT))
+  rule #pointeeProjection(SRC:TypeInfo, TGT)
+    => #pointeeProjectionTarget(SRC, TGT)
     requires #isArrayType(SRC)
-     andBool #zeroFieldOffset(LAYOUT)
+     andBool #wholeArrayTargetCompatible(SRC, TGT)
+     andBool SRC =/=K TGT
     [priority(42)]
 
   rule #pointeeProjection(typeInfoArrayType(TY1, _), TY2)
@@ -185,6 +186,20 @@ the source-first strategy.
   rule #layoutOffsets(someLayoutShape(layoutShape(fieldsShapeArbitrary(mk(OFFSETS)), _, _, _, _))) => OFFSETS
   rule #layoutOffsets(noLayoutShape) => .MachineSizes
   rule #layoutOffsets(_) => .MachineSizes [owise]
+
+  syntax Bool ::= #wholeArrayTargetCompatible ( TypeInfo , TypeInfo ) [function, total]
+  // ----------------------------------------------------------------------------
+  rule #wholeArrayTargetCompatible(SRC, SRC) => true
+
+  rule #wholeArrayTargetCompatible(SRC, typeInfoStructType(_, _, FIELD .Tys, LAYOUT))
+    => #wholeArrayTargetCompatible(SRC, lookupTy(FIELD))
+    requires #zeroFieldOffset(LAYOUT)
+
+  rule #wholeArrayTargetCompatible(SRC, typeInfoArrayType(ELEM_TY, someTyConst(tyConst(KIND, _))))
+    => #wholeArrayTargetCompatible(SRC, lookupTy(ELEM_TY))
+    requires readTyConstInt(KIND) ==Int 1
+
+  rule #wholeArrayTargetCompatible(_, _) => false [owise]
 ```
 
 --------------------------------------------------

--- a/kmir/src/kmir/kdist/mir-semantics/rt/types.md
+++ b/kmir/src/kmir/kdist/mir-semantics/rt/types.md
@@ -113,14 +113,10 @@ the source should be wrapped rather than unwrapped (e.g., `*const [u8;2] → *co
         )
     requires #zeroFieldOffset(LAYOUT)
 
-  rule #pointeeProjection(SRC:TypeInfo, typeInfoStructType(_NAME, _ADTDEF, FIELD .Tys, LAYOUT))
-    => maybeConcatProj(
-          projectionElemWrapStruct,
-          #pointeeProjection(SRC, lookupTy(FIELD))
-        )
+  rule #pointeeProjection(SRC:TypeInfo, typeInfoStructType(NAME, ADTDEF, FIELD .Tys, LAYOUT))
+    => #pointeeProjectionTarget(SRC, typeInfoStructType(NAME, ADTDEF, FIELD .Tys, LAYOUT))
     requires #isArrayType(SRC)
-    andBool #zeroFieldOffset(LAYOUT)
-    andBool lookupTy(FIELD) ==K SRC
+     andBool #zeroFieldOffset(LAYOUT)
     [priority(42)]
 
   rule #pointeeProjection(typeInfoArrayType(TY1, _), TY2)


### PR DESCRIPTION
## Summary
- relax transparent-wrapper pointee projection so array-to-wrapper pointer casts can advance
- cover wrapper, nested-wrapper, and singleton-wrapped-array pointer cast regressions with one shared semantic fix

## Test plan
- `cd kmir && uv run pytest src/tests/integration/test_integration.py -k "ptr-cast-array-to-wrapper-fail or ptr-cast-array-to-nested-wrapper-fail or ptr-cast-array-to-singleton-wrapped-array-fail or ptr-through-wrapper-fail or raw-ptr-cast-fail or ref-ptr-cast-elem-fail or ref-ptr-cast-elem-offset-fail or pointer-cast-length-test-fail" -q`