### PR TITLE
Increased timeout of `Haskell Exec SMIR` CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           - name: 'Haskell Exec SMIR'
             test-args: '-k "test_exec_smir and haskell"'
             parallel: 6
-            timeout: 20
+            timeout: 30
           - name: 'Haskell Termination'
             test-args: '-k test_prove_termination'
             parallel: 6


### PR DESCRIPTION
Our PRs currently mostly fail CI due to the `Haskell Exec SMIR` CI test timing out. I increased it from 20 to 30 minutes.