### PR TITLE
Another increase of timeout for Haskell Exec SMIR CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           - name: 'Haskell Exec SMIR'
             test-args: '-k "test_exec_smir and haskell"'
             parallel: 6
-            timeout: 30
+            timeout: 50
           - name: 'Haskell Termination'
             test-args: '-k test_prove_termination'
             parallel: 6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           - name: 'Haskell Exec SMIR'
             test-args: '-k "test_exec_smir and haskell"'
             parallel: 6
-            timeout: 50
+            timeout: 60
           - name: 'Haskell Termination'
             test-args: '-k test_prove_termination'
             parallel: 6


### PR DESCRIPTION
The timeout increase [here](https://github.com/runtimeverification/mir-semantics/pull/1021) is not enough (depending on the state of the GH runners, this is still a bit too tight). I measured locally, and it took around 40 minutes, so I added another 10 as a leeway for a total of 50 min.