### PR TITLE
Increase timeouts in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,15 +69,15 @@ jobs:
           - name: 'Haskell Termination'
             test-args: '-k test_prove_termination'
             parallel: 6
-            timeout: 40
+            timeout: 60
           - name: 'Haskell Proofs'
             test-args: '-k "test_prove and not test_prove_termination"'
             parallel: 6
-            timeout: 120
+            timeout: 150
           - name: 'Remainder'
             test-args: '-k "not llvm and not test_run_smir_random and not test_exec_smir and not test_prove_termination and not test_prove"'
             parallel: 6
-            timeout: 40
+            timeout: 60
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           - name: 'LLVM Concrete Tests'
             test-args: '-k "llvm or test_run_smir_random"'
             parallel: 12
-            timeout: 30
+            timeout: 60
           - name: 'Haskell Exec SMIR'
             test-args: '-k "test_exec_smir and haskell"'
             parallel: 6
@@ -69,7 +69,7 @@ jobs:
           - name: 'Haskell Termination'
             test-args: '-k test_prove_termination'
             parallel: 6
-            timeout: 20
+            timeout: 40
           - name: 'Haskell Proofs'
             test-args: '-k "test_prove and not test_prove_termination"'
             parallel: 6
@@ -77,7 +77,7 @@ jobs:
           - name: 'Remainder'
             test-args: '-k "not llvm and not test_run_smir_random and not test_exec_smir and not test_prove_termination and not test_prove"'
             parallel: 6
-            timeout: 20
+            timeout: 40
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4


### PR DESCRIPTION
The timeout limits for our CI tests are tight. Depending on the state of the github runners, our CI often fails with just a few more minutes needed. I have noticed test runs being cancelled while making progress, at 90% + (even just after the test have been completed). It would be better to have them be more generous, as having to rerun jobs cancelled due to this is actually leading to more time on the runners.