### PR TITLE
`kmir show` streams output instead of joining into one string

### DIFF
--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -193,16 +193,23 @@ def _kmir_show(opts: ShowOpts) -> None:
         print(f'Module written to: {opts.to_module}')
     else:
         # Stream lines to stdout to avoid holding the entire output in memory
+        last_line = lines[-1] if lines else ''
         _flush_lines(lines)
         del lines
         if opts.statistics:
-            print()
-            _flush_lines(render_statistics(proof))
+            if last_line != '':
+                print()
+            stat_lines = render_statistics(proof)
+            last_line = stat_lines[-1] if stat_lines else last_line
+            _flush_lines(stat_lines)
         if effective_rule_edges:
             print('# Rules: ')
-            _flush_lines(render_rules(proof, effective_rule_edges))
+            rule_lines = render_rules(proof, effective_rule_edges)
+            last_line = rule_lines[-1] if rule_lines else last_line
+            _flush_lines(rule_lines)
         if opts.leaves:
-            print()
+            if last_line != '':
+                print()
             _flush_lines(render_leaf_k_cells(proof, node_printer.cterm_show, smir_info=node_printer.smir_info))
 
 

--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -43,7 +43,7 @@ _LOGGER: Final = logging.getLogger(__name__)
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
 
-def _flush_lines(lines: 'Iterable[str]') -> None:
+def _flush_lines(lines: Iterable[str]) -> None:
     """Print lines to stdout one at a time, then release the list if possible."""
     for line in lines:
         print(line)

--- a/kmir/src/kmir/__main__.py
+++ b/kmir/src/kmir/__main__.py
@@ -34,13 +34,21 @@ from .utils import render_leaf_k_cells, render_rules, render_statistics
 
 if TYPE_CHECKING:
     from argparse import Namespace
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
     from typing import Final
 
     from .options import KMirOpts
 
 _LOGGER: Final = logging.getLogger(__name__)
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
+
+
+def _flush_lines(lines: 'Iterable[str]') -> None:
+    """Print lines to stdout one at a time, then release the list if possible."""
+    for line in lines:
+        print(line)
+    if hasattr(lines, 'clear'):
+        lines.clear()
 
 
 def _kmir_run(opts: RunOpts) -> None:
@@ -171,24 +179,31 @@ def _kmir_show(opts: ShowOpts) -> None:
         omit_cells=tuple(all_omit_cells),
         to_module=opts.to_module is not None,
     )
-    if opts.statistics:
-        if lines and lines[-1] != '':
-            lines.append('')
-        lines.extend(render_statistics(proof))
-    if effective_rule_edges:
-        lines.append('# Rules: ')
-        lines.extend(render_rules(proof, effective_rule_edges))
-    if opts.leaves:
-        if lines and lines[-1] != '':
-            lines.append('')
-        lines.extend(render_leaf_k_cells(proof, node_printer.cterm_show, smir_info=node_printer.smir_info))
 
     # Handle --to-module output
     if opts.to_module:
+        if opts.statistics:
+            lines.extend(render_statistics(proof))
+        if effective_rule_edges:
+            lines.append('# Rules: ')
+            lines.extend(render_rules(proof, effective_rule_edges))
+        if opts.leaves:
+            lines.extend(render_leaf_k_cells(proof, node_printer.cterm_show, smir_info=node_printer.smir_info))
         _write_to_module(kmir, proof, opts.to_module)
         print(f'Module written to: {opts.to_module}')
     else:
-        print('\n'.join(lines))
+        # Stream lines to stdout to avoid holding the entire output in memory
+        _flush_lines(lines)
+        del lines
+        if opts.statistics:
+            print()
+            _flush_lines(render_statistics(proof))
+        if effective_rule_edges:
+            print('# Rules: ')
+            _flush_lines(render_rules(proof, effective_rule_edges))
+        if opts.leaves:
+            print()
+            _flush_lines(render_leaf_k_cells(proof, node_printer.cterm_show, smir_info=node_printer.smir_info))
 
 
 def _kmir_prune(opts: PruneOpts) -> None:


### PR DESCRIPTION
This PR addresses https://github.com/runtimeverification/mir-semantics/issues/1060.

`kmir show` streams output to reduce memory usage

`kmir show` previously accumulated the entire output as a list of strings, then joined them into a single string before printing to stdout. For large proofs (2000+ nodes), this caused out-of-memory failures during stats generation — even after the proof itself completed successfully.

This PR changes `_kmir_show()` to stream each section's output to stdout independently, freeing memory between sections:

1. The main tree output (`shower.show()`) is printed line-by-line and released before statistics are generated
2. `render_statistics()`, `render_rules()`, and `render_leaf_k_cells()` are each printed and released independently
3. Blank line separators between sections are added conditionally (matching original behavior) to avoid double-blank lines

A helper `_flush_lines()` accepts accepting any iterable for flexibility. Note that the remaining peak memory cost (`shower.show()` building the full tree output in memory) is on pyk's side (`APRProofShow.show()` returns `list[str]`).

**Observed impact:** `kmir show` OOM'd after a large successful proof ([transfer_multisig](https://kaas.runtimeverification.com/app/organization/runtimeverification/solana-token/job/5F33ASWNe3Tf4B2qjEcq3E?job_hl=vH7kuxXApyrUUpUE7NKc35)). The proof data was intact but stats could not be generated. With this change, each section's memory is freed before the next one starts.

**Testing:** Output is identical to the previous version, verified by diff against existing proof outputs (both standalone and when appending a header via `run-proofs.sh`), and by the `test_cli_show_*` integration tests.