### PR TITLE
Adding `latest` tag to release docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,9 @@ jobs:
           push: true
           build-args: |
             K_VERSION=${{ steps.set-image-name.outputs.k-version }}
-          tags: ${{ steps.set-image-name.outputs.image-name }}:ubuntu-jammy-${{ steps.set-image-name.outputs.kmir-version }}
+          tags: |
+            ${{ steps.set-image-name.outputs.image-name }}:ubuntu-jammy-${{ steps.set-image-name.outputs.kmir-version }}
+            ${{ steps.set-image-name.outputs.image-name }}:ubuntu-jammy-latest
 
       - name: 'On failure, delete drafted release'
         if: failure()


### PR DESCRIPTION
In order to pull the latest version from [dockerhub](https://hub.docker.com/r/runtimeverificationinc/kmir/tags) a `ubuntu-jammy-latest` tag is added to the release.