### PR TITLE
Dedupe function selector rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,21 @@ make test-unit
 make test-integration
 
 # Run a single test
-uv --directory kmir run pytest kmir/src/tests/integration/test_prove.py::test_prove -k "test_name"
+make test-integration TEST_ARGS='-k "test_name"'
 
 # Generate and parse SMIR for test files
 make smir-parse-tests
 ```
+
+You can pass `PARALLEL=N` to increase parallelism for a given test-run.
+You can add `TEST_ARGS=--update-expected-output` to update golden output files.
+Tests take up to 30 minutes to run, so set your timeout accordingly.
+
+When updating the expected output, make sure to inspect the updated test output and check that it's explained by the changes made to the code.
+If not, please provide a brief explanation of could have happend with the test, or what adjustments are needed.
+
+To run individual tests, add `TEST_ARGS='-k "test_id1 or test_id2"'` to the `make` invocation.
+For very specific queries, skip make and run the `uv --directory kmir run pytest path/to/test/file.py::test_name[test_selector]` directly with appropriate arguments.
 
 ### Code Quality
 ```bash

--- a/kmir/src/kmir/_prove.py
+++ b/kmir/src/kmir/_prove.py
@@ -357,8 +357,7 @@ def _cut_point_rules(
     ):
         cut_point_rules.append('KMIR-CONTROL-FLOW.termCallFunction')
     if break_on_function:
-        cut_point_rules.append('KMIR-CONTROL-FLOW.termCallFunctionFilter')
-        cut_point_rules.append('KMIR-CONTROL-FLOW.termCallIntrinsicFilter')
+        cut_point_rules.append('KMIR-CONTROL-FLOW.termCallFunctionFilterMatch')
     if break_on_terminator_assert or break_every_terminator or break_every_step:
         cut_point_rules.append('KMIR-CONTROL-FLOW.termAssert')
     if break_on_terminator_drop or break_every_terminator or break_every_step:

--- a/kmir/src/kmir/kdist/mir-semantics/kmir.md
+++ b/kmir/src/kmir/kdist/mir-semantics/kmir.md
@@ -309,6 +309,7 @@ where the returned result should go.
 
 ```k
   syntax KItem ::= #execTerminatorCall(fty: Ty, func: MonoItemKind, args: Operands, destination: Place, target: MaybeBasicBlockIdx, unwind: UnwindAction, Span)
+  syntax KItem ::= #checkFunctionFilter(MonoItemKind)
 
   rule <k> #execTerminator(terminator(terminatorKindCall(operandConstant(constOperand(_, _, mirConst(constantKindZeroSized, Ty, _))), ARGS, DEST, TARGET, UNWIND), SPAN))
         => #execTerminatorCall(Ty, lookupFunction(Ty), ARGS, DEST, TARGET, UNWIND, SPAN)
@@ -336,23 +337,14 @@ where the returned result should go.
   // Intrinsic function call - execute directly without state switching
   rule [termCallIntrinsic]:
         <k> #execTerminatorCall(_, FUNC, ARGS, DEST, TARGET, _UNWIND, SPAN) ~> _
-         => #execIntrinsic(FUNC, ARGS, DEST, SPAN) ~> #continueAt(TARGET)
+         => #checkFunctionFilter(FUNC) ~> #execIntrinsic(FUNC, ARGS, DEST, SPAN) ~> #continueAt(TARGET)
         </k>
     requires isIntrinsicFunction(FUNC)
-     andBool notBool #functionNameMatchesEnv(getFunctionName(FUNC))
-
-  // Intrinsic function call to a function in the break-on set - same as termCallIntrinsic but separate rule id for cut-point
-  rule [termCallIntrinsicFilter]:
-        <k> #execTerminatorCall(_, FUNC, ARGS, DEST, TARGET, _UNWIND, SPAN) ~> _
-         => #execIntrinsic(FUNC, ARGS, DEST, SPAN) ~> #continueAt(TARGET)
-        </k>
-    requires isIntrinsicFunction(FUNC)
-     andBool #functionNameMatchesEnv(getFunctionName(FUNC))
 
   // Regular function call - full state switching and stack setup
   rule [termCallFunction]:
        <k> #execTerminatorCall(FTY, FUNC, ARGS, DEST, TARGET, UNWIND, SPAN) ~> _
-        => #setUpCalleeData(FUNC, ARGS, SPAN)
+        => #checkFunctionFilter(FUNC) ~> #setUpCalleeData(FUNC, ARGS, SPAN)
        </k>
        <currentFunc> CALLER => FTY </currentFunc>
        <currentFrame>
@@ -365,25 +357,15 @@ where the returned result should go.
        </currentFrame>
        <stack> STACK => ListItem(StackFrame(OLDCALLER, OLDDEST, OLDTARGET, OLDUNWIND, LOCALS)) STACK </stack>
     requires notBool isIntrinsicFunction(FUNC)
-     andBool notBool #functionNameMatchesEnv(getFunctionName(FUNC))
 
-  // Function call to a function in the break-on set - same as termCallFunction but separate rule id for cut-point
-  rule [termCallFunctionFilter]:
-       <k> #execTerminatorCall(FTY, FUNC, ARGS, DEST, TARGET, UNWIND, SPAN) ~> _
-        => #setUpCalleeData(FUNC, ARGS, SPAN)
-       </k>
-       <currentFunc> CALLER => FTY </currentFunc>
-       <currentFrame>
-         <currentBody> _ </currentBody>
-         <caller> OLDCALLER => CALLER </caller>
-         <dest> OLDDEST => DEST </dest>
-         <target> OLDTARGET => TARGET </target>
-         <unwind> OLDUNWIND => UNWIND </unwind>
-         <locals> LOCALS </locals>
-       </currentFrame>
-       <stack> STACK => ListItem(StackFrame(OLDCALLER, OLDDEST, OLDTARGET, OLDUNWIND, LOCALS)) STACK </stack>
-    requires notBool isIntrinsicFunction(FUNC)
-     andBool #functionNameMatchesEnv(getFunctionName(FUNC))
+  // Filter check injected after every call: fires as a cut-point only when the function matches the break-on list
+  rule [termCallFunctionFilterMatch]:
+       <k> #checkFunctionFilter(FUNC) => .K ... </k>
+    requires #functionNameMatchesEnv(getFunctionName(FUNC))
+
+  rule [termCallFunctionFilterNoMatch]:
+       <k> #checkFunctionFilter(FUNC) => .K ... </k>
+    requires notBool #functionNameMatchesEnv(getFunctionName(FUNC))
 
   syntax Bool ::= isIntrinsicFunction(MonoItemKind) [function]
   rule isIntrinsicFunction(IntrinsicFunction(_)) => true

--- a/kmir/src/tests/integration/data/crate-tests/single-bin/single_exe::a_module::twice.expected
+++ b/kmir/src/tests/integration/data/crate-tests/single-bin/single_exe::a_module::twice.expected
@@ -2,7 +2,7 @@
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │
-│  (44 steps)
+│  (46 steps)
 ├─ 3 (split)
 │   #expect ( BoolVal ( notBool ARG_UINT1:Int +Int ARG_UINT1:Int &Int 18446744073709
 ┃

--- a/kmir/src/tests/integration/data/crate-tests/single-bin/single_exe::main.expected
+++ b/kmir/src/tests/integration/data/crate-tests/single-bin/single_exe::main.expected
@@ -2,7 +2,7 @@
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │
-│  (228 steps)
+│  (231 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │

--- a/kmir/src/tests/integration/data/crate-tests/single-dylib/small_test_dylib::add.expected
+++ b/kmir/src/tests/integration/data/crate-tests/single-dylib/small_test_dylib::add.expected
@@ -2,7 +2,7 @@
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │
-│  (35 steps)
+│  (36 steps)
 ├─ 3 (split)
 │   #expect ( BoolVal ( notBool ARG_UINT1:Int +Int ARG_UINT2:Int &Int 18446744073709
 ┃

--- a/kmir/src/tests/integration/data/crate-tests/single-lib/small_test_lib::testing::test_add_in_range.expected
+++ b/kmir/src/tests/integration/data/crate-tests/single-lib/small_test_lib::testing::test_add_in_range.expected
@@ -2,7 +2,7 @@
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │
-│  (114 steps)
+│  (116 steps)
 ├─ 3 (split)
 │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 1 ) )
 ┃
@@ -14,7 +14,7 @@
 ┃  ├─ 4
 ┃  │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 1 ) )
 ┃  │
-┃  │  (6 steps)
+┃  │  (7 steps)
 ┃  └─ 6 (stuck, leaf)
 ┃      #setUpCalleeData ( monoItemFn ( ... name: symbol ( "_ZN3std7process4exit17h<hash>
 ┃
@@ -25,7 +25,7 @@
    ├─ 5
    │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 1 ) )
    │
-   │  (182 steps)
+   │  (183 steps)
    ├─ 7 (terminal)
    │   #EndProgram ~> .K
    │

--- a/kmir/src/tests/integration/data/crate-tests/two-crate-bin/crate2::main.expected
+++ b/kmir/src/tests/integration/data/crate-tests/two-crate-bin/crate2::main.expected
@@ -2,7 +2,7 @@
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │
-│  (737 steps)
+│  (746 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │

--- a/kmir/src/tests/integration/data/crate-tests/two-crate-dylib/crate2::test_crate1_with.expected
+++ b/kmir/src/tests/integration/data/crate-tests/two-crate-dylib/crate2::test_crate1_with.expected
@@ -2,7 +2,7 @@
 ┌─ 1 (root, init)
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │
-│  (216 steps)
+│  (220 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │

--- a/kmir/src/tests/integration/data/prove-rs/show/assert-inhabited-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/assert-inhabited-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (10 steps)
+│  (12 steps)
 └─ 3 (stuck, leaf)
     #ProgramError ( AssertInhabitedFailure ) ~> .K
     function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/assert-true.main.cli-custom-printer.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/assert-true.main.cli-custom-printer.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: src/rust/library/std/src/rt.rs:194
 │
-│  (7 steps)
+│  (8 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/assert-true.main.cli-default-printer.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/assert-true.main.cli-default-printer.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: src/rust/library/std/src/rt.rs:194
 │
-│  (7 steps)
+│  (8 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/assert_eq_exp.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/assert_eq_exp.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (148 steps)
+│  (149 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/assume-cheatcode-conflict-fail.check_assume_conflict.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/assume-cheatcode-conflict-fail.check_assume_conflict.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (61 steps)
+│  (63 steps)
 └─ 3 (stuck, leaf)
     #setUpCalleeData ( monoItemFn ( ... name: symbol ( "_ZN4core9panicking5panic17h<hash>
     span: 32

--- a/kmir/src/tests/integration/data/prove-rs/show/bitwise-not-shift.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/bitwise-not-shift.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (837 steps)
+│  (844 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/box_heap_alloc-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/box_heap_alloc-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (73 steps)
+│  (76 steps)
 ├─ 3
 │   #cast ( Integer ( 4 , 64 , false ) , castKindTransmute , ty ( 29 ) , ty ( 50 ) )
 │   span: 186

--- a/kmir/src/tests/integration/data/prove-rs/show/break-on-function.main.cli-break-on-function.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/break-on-function.main.cli-break-on-function.expected
@@ -3,10 +3,10 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: src/rust/library/std/src/rt.rs:194
 │
-│  (7 steps)
+│  (9 steps)
 ├─ 3
-│   #execTerminatorCall ( ty ( 31 ) , monoItemFn ( ... name: symbol ( "foo" ) , id:
-│   function: main
+│   #checkFunctionFilter ( monoItemFn ( ... name: symbol ( "foo" ) , id: defId ( 7 )
+│   function: foo
 │   span: /prove-rs/break-on-function.rs:4
 │
 │  (1 step)
@@ -15,10 +15,10 @@
 │   function: foo
 │   span: /prove-rs/break-on-function.rs:4
 │
-│  (5 steps)
+│  (6 steps)
 ├─ 5
-│   #execTerminatorCall ( ty ( 26 ) , monoItemFn ( ... name: symbol ( "std::hint::bl
-│   function: foo
+│   #checkFunctionFilter ( monoItemFn ( ... name: symbol ( "std::hint::black_box::<i
+│   function: std::hint::black_box::<i32>
 │   span: /rust/library/core/src/hint.rs:389
 │
 │  (1 step)
@@ -27,9 +27,10 @@
 │   function: std::hint::black_box::<i32>
 │   span: /rust/library/core/src/hint.rs:389
 │
-│  (12 steps)
+│  (13 steps)
 ├─ 7
-│   #execTerminatorCall ( ty ( 25 ) , IntrinsicFunction ( symbol ( "black_box" ) ) ,
+│   #checkFunctionFilter ( IntrinsicFunction ( symbol ( "black_box" ) ) )
+~> #execIn
 │   function: std::hint::black_box::<i32>
 │   span: /rust/library/core/src/hint.rs:389
 │
@@ -39,7 +40,7 @@
 │   function: std::hint::black_box::<i32>
 │   span: /rust/library/core/src/hint.rs:389
 │
-│  (41 steps)
+│  (42 steps)
 ├─ 9 (terminal)
 │   #EndProgram ~> .K
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/interior-mut-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/interior-mut-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (877 steps)
+│  (888 steps)
 └─ 3 (stuck, leaf)
     #setUpCalleeData ( monoItemFn ( ... name: symbol ( "_ZN4core4cell22panic_already
     span: 32

--- a/kmir/src/tests/integration/data/prove-rs/show/interior-mut3-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/interior-mut3-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (94 steps)
+│  (97 steps)
 ├─ 3
 │   #cast ( PtrLocal ( 0 , place ( ... local: local ( 1 ) , projection: projectionEl
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/iter_next_3.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/iter_next_3.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (2028 steps)
+│  (2037 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/iterator-simple.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/iterator-simple.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (798 steps)
+│  (803 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/local-raw-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/local-raw-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (46 steps)
+│  (47 steps)
 ├─ 3
 │   #cast ( PtrLocal ( 0 , place ( ... local: local ( 1 ) , projection: projectionEl
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/niche-enum.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/niche-enum.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (740 steps)
+│  (749 steps)
 ├─ 3 (terminal)
 │   #EndProgram ~> .K
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/niche-enum.smir.foo.cli-stats-leaves.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/niche-enum.smir.foo.cli-stats-leaves.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: src/rust/library/std/src/rt.rs:194
 │
-│  (14 steps)
+│  (15 steps)
 ├─ 3 (split)
 │   #selectBlock ( switchTargets ( ... branches: branch ( 1 , basicBlockIdx ( 3 ) )
 │   function: foo
@@ -94,11 +94,11 @@ Node roles (exclusive):
 Leaf paths from init:
   total leaves (non-root): 1
   reachable leaves       : 1
-  total steps            : 34
+  total steps            : 35
 
-  leaf 2 (path 1/3): steps 34, path 1 -> 3 -> 5 -> 7 -> 9 -> 11 -> 2
-  leaf 2 (path 2/3): steps 47, path 1 -> 3 -> 4 -> 6 -> 2
-  leaf 2 (path 3/3): steps 48, path 1 -> 3 -> 5 -> 7 -> 8 -> 10 -> 2
+  leaf 2 (path 1/3): steps 35, path 1 -> 3 -> 5 -> 7 -> 9 -> 11 -> 2
+  leaf 2 (path 2/3): steps 48, path 1 -> 3 -> 4 -> 6 -> 2
+  leaf 2 (path 3/3): steps 49, path 1 -> 3 -> 5 -> 7 -> 8 -> 10 -> 2
 
 LEAF <k> CELLS
 ---------------

--- a/kmir/src/tests/integration/data/prove-rs/show/offset-u8-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/offset-u8-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (35 steps)
+│  (38 steps)
 └─ 3 (stuck, leaf)
     #traverseProjection ( toAlloc ( allocId ( 0 ) ) , StringVal ( "123" ) , .Project
     span: 48

--- a/kmir/src/tests/integration/data/prove-rs/show/pointer-cast-length-test-fail.array_cast_test.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/pointer-cast-length-test-fail.array_cast_test.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (44 steps)
+│  (45 steps)
 ├─ 3 (split)
 │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 2 ) )
 ┃
@@ -15,7 +15,7 @@
 ┃  ├─ 4
 ┃  │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 2 ) )
 ┃  │
-┃  │  (6 steps)
+┃  │  (7 steps)
 ┃  └─ 6 (stuck, leaf)
 ┃      #setUpCalleeData ( monoItemFn ( ... name: symbol ( "_ZN4core9panicking5panic17h<hash>
 ┃      span: 32
@@ -27,7 +27,7 @@
    ├─ 5
    │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 2 ) )
    │
-   │  (211 steps)
+   │  (213 steps)
    ├─ 7
    │   #traverseProjection ( toStack ( 1 , local ( 2 ) ) , Range ( range ( #mapOffset (
    │   span: 87
@@ -51,7 +51,7 @@
    ┃  ┃  │   #traverseProjection ( toStack ( 1 , local ( 2 ) ) , Range ( range ( range ( #map
    ┃  ┃  │   span: 87
    ┃  ┃  │
-   ┃  ┃  │  (114 steps)
+   ┃  ┃  │  (115 steps)
    ┃  ┃  └─ 13 (stuck, leaf)
    ┃  ┃      #traverseProjection ( toLocal ( 5 ) , Range ( range ( #mapOffset ( ARG_ARRAY1:Li
    ┃  ┃      span: 97

--- a/kmir/src/tests/integration/data/prove-rs/show/ptr-cast-array-to-nested-wrapper-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/ptr-cast-array-to-nested-wrapper-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (68 steps)
+│  (69 steps)
 ├─ 3
 │   #cast ( PtrLocal ( 0 , place ( ... local: local ( 1 ) , projection: projectionEl
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/ptr-cast-array-to-singleton-wrapped-array-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/ptr-cast-array-to-singleton-wrapped-array-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (68 steps)
+│  (69 steps)
 ├─ 3
 │   #cast ( PtrLocal ( 0 , place ( ... local: local ( 1 ) , projection: projectionEl
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/ptr-cast-array-to-wrapper-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/ptr-cast-array-to-wrapper-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (68 steps)
+│  (69 steps)
 ├─ 3
 │   #cast ( PtrLocal ( 0 , place ( ... local: local ( 1 ) , projection: projectionEl
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/ptr-through-wrapper-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/ptr-through-wrapper-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (46 steps)
+│  (47 steps)
 ├─ 3
 │   #cast ( PtrLocal ( 0 , place ( ... local: local ( 1 ) , projection: projectionEl
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/raw-ptr-cast-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/raw-ptr-cast-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (60 steps)
+│  (61 steps)
 ├─ 3
 │   #cast ( PtrLocal ( 0 , place ( ... local: local ( 1 ) , projection: projectionEl
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/ref-ptr-cast-elem-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/ref-ptr-cast-elem-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (64 steps)
+│  (65 steps)
 ├─ 3
 │   #cast ( PtrLocal ( 0 , place ( ... local: local ( 1 ) , projection: projectionEl
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/ref-ptr-cast-elem-offset-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/ref-ptr-cast-elem-offset-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (125 steps)
+│  (127 steps)
 ├─ 3
 │   #cast ( PtrLocal ( 0 , place ( ... local: local ( 1 ) , projection: projectionEl
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.eats_all_args.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.eats_all_args.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (52 steps)
+│  (53 steps)
 ├─ 3 (split)
 │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 3 ) )
 ┃

--- a/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.main.cli-stats-leaves.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.main.cli-stats-leaves.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: src/rust/library/std/src/rt.rs:194
 │
-│  (566 steps)
+│  (569 steps)
 └─ 3 (stuck, leaf)
     #setUpCalleeData ( monoItemFn ( ... name: symbol ( "_ZN4core9panicking5panic17h<hash>
     span: no-location:0
@@ -25,9 +25,9 @@ Node roles (exclusive):
 Leaf paths from init:
   total leaves (non-root): 1
   reachable leaves       : 1
-  total steps            : 566
+  total steps            : 569
 
-  leaf 3: steps 566, path 1 -> 3
+  leaf 3: steps 569, path 1 -> 3
 
 LEAF <k> CELLS
 ---------------

--- a/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/symbolic-args-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (566 steps)
+│  (569 steps)
 └─ 3 (stuck, leaf)
     #setUpCalleeData ( monoItemFn ( ... name: symbol ( "_ZN4core9panicking5panic17h<hash>
     span: 32

--- a/kmir/src/tests/integration/data/prove-rs/show/symbolic-structs-fail.eats_struct_args.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/symbolic-structs-fail.eats_struct_args.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (61 steps)
+│  (62 steps)
 ├─ 3 (split)
 │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 2 ) )
 ┃
@@ -27,7 +27,7 @@
 ┃  ┃  ├─ 8
 ┃  ┃  │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 5 ) )
 ┃  ┃  │
-┃  ┃  │  (6 steps)
+┃  ┃  │  (7 steps)
 ┃  ┃  └─ 10 (stuck, leaf)
 ┃  ┃      #setUpCalleeData ( monoItemFn ( ... name: symbol ( "_ZN4core9panicking5panic17h<hash>
 ┃  ┃      span: 32

--- a/kmir/src/tests/integration/data/prove-rs/show/test_offset_from-fail.testing.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/test_offset_from-fail.testing.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (297 steps)
+│  (298 steps)
 ├─ 3 (split)
 │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 8 ) )
 ┃
@@ -15,7 +15,7 @@
 ┃  ├─ 4
 ┃  │   #selectBlock ( switchTargets ( ... branches: branch ( 0 , basicBlockIdx ( 8 ) )
 ┃  │
-┃  │  (588 steps)
+┃  │  (594 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │
@@ -43,7 +43,7 @@
    ┃  ├─ 8
    ┃  │   #selectBlock ( switchTargets ( ... branches: branch ( 1 , basicBlockIdx ( 7 ) )
    ┃  │
-   ┃  │  (101 steps)
+   ┃  │  (103 steps)
    ┃  └─ 10 (stuck, leaf)
    ┃      #ProgramError ( #UBErrorPtrOffsetDiff ( PtrLocal ( 1 , place ( ... local: local
    ┃
@@ -66,7 +66,7 @@
       ┃  ├─ 12
       ┃  │   #selectBlock ( switchTargets ( ... branches: branch ( 2 , basicBlockIdx ( 6 ) )
       ┃  │
-      ┃  │  (101 steps)
+      ┃  │  (103 steps)
       ┃  └─ 14 (stuck, leaf)
       ┃      #ProgramError ( #UBErrorPtrOffsetDiff ( PtrLocal ( 1 , place ( ... local: local
       ┃
@@ -89,7 +89,7 @@
          ┃  ├─ 16
          ┃  │   #selectBlock ( switchTargets ( ... branches: branch ( 3 , basicBlockIdx ( 5 ) )
          ┃  │
-         ┃  │  (17 steps)
+         ┃  │  (18 steps)
          ┃  └─ 18 (stuck, leaf)
          ┃      #ProgramError ( #UBErrorPtrOffsetDiff ( PtrLocal ( 0 , place ( ... local: local
          ┃

--- a/kmir/src/tests/integration/data/prove-rs/show/transmute-maybe-uninit-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/transmute-maybe-uninit-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (16 steps)
+│  (17 steps)
 └─ 3 (stuck, leaf)
     #ProgramError ( #UBInvalidTransmuteMaybeUninit )
 ~> #freezer#setLocalValue(_,_)_

--- a/kmir/src/tests/integration/data/prove-rs/show/transmute-u8-to-enum-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/transmute-u8-to-enum-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (15 steps)
+│  (16 steps)
 └─ 3 (stuck, leaf)
     #ProgramError ( #UBErrorInvalidDiscriminantsInEnumCast ) ~> .K
     function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/unions-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/unions-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (76 steps)
+│  (77 steps)
 └─ 3 (stuck, leaf)
     #traverseProjection ( toLocal ( 1 ) , Union ( fieldIdx ( 0 ) , Integer ( -1 , 8
     function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/volatile_load_static-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/volatile_load_static-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (10 steps)
+│  (11 steps)
 ├─ 3
 │   #decodeConstant ( constantKindAllocated ( allocation ( ... bytes: b"\x00\x00\x00
 │   function: main

--- a/kmir/src/tests/integration/data/prove-rs/show/volatile_store_static-fail.main.expected
+++ b/kmir/src/tests/integration/data/prove-rs/show/volatile_store_static-fail.main.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (10 steps)
+│  (11 steps)
 ├─ 3
 │   #decodeConstant ( constantKindAllocated ( allocation ( ... bytes: b"\x00\x00\x00
 │   function: main

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_INT1:Int , 128 , true ) , Intege
 │   span: 301
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int +Int ARG_INT2:Int , 128 , Signed ) , 128 , tru
 ┃  │   span: 301
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_INT1:Int , 16 , true ) , Integer
 │   span: 115
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int +Int ARG_INT2:Int , 16 , Signed ) , 16 , true
 ┃  │   span: 115
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_INT1:Int , 32 , true ) , Integer
 │   span: 146
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int +Int ARG_INT2:Int , 32 , Signed ) , 32 , true
 ┃  │   span: 146
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_INT1:Int , 64 , true ) , Integer
 │   span: 177
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int +Int ARG_INT2:Int , 64 , Signed ) , 64 , true
 ┃  │   span: 177
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_i8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_INT1:Int , 8 , true ) , Integer
 │   span: 53
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int +Int ARG_INT2:Int , 8 , Signed ) , 8 , true )
 ┃  │   span: 53
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_UINT1:Int , 128 , false ) , Inte
 │   span: 332
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int +Int ARG_UINT2:Int &Int 34028236692093846346337460743176
 ┃  │   span: 332
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_UINT1:Int , 16 , false ) , Integ
 │   span: 208
@@ -16,7 +16,7 @@
 ~> #freezer
 ┃  │   span: 208
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_UINT1:Int , 32 , false ) , Integ
 │   span: 239
@@ -16,7 +16,7 @@
 ~> #fr
 ┃  │   span: 239
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_UINT1:Int , 64 , false ) , Integ
 │   span: 270
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int +Int ARG_UINT2:Int &Int 18446744073709551615 , 64 , fals
 ┃  │   span: 270
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_add-fail.unchecked_add_u8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpAddUnchecked , Integer ( ARG_UINT1:Int , 8 , false ) , Intege
 │   span: 84
@@ -16,7 +16,7 @@
 ~> #freezer#se
 ┃  │   span: 84
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_INT1:Int , 128 , true ) , Intege
 │   span: 301
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int *Int ARG_INT2:Int , 128 , Signed ) , 128 , tru
 ┃  │   span: 301
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_INT1:Int , 16 , true ) , Integer
 │   span: 115
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int *Int ARG_INT2:Int , 16 , Signed ) , 16 , true
 ┃  │   span: 115
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_INT1:Int , 32 , true ) , Integer
 │   span: 146
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int *Int ARG_INT2:Int , 32 , Signed ) , 32 , true
 ┃  │   span: 146
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_INT1:Int , 64 , true ) , Integer
 │   span: 177
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int *Int ARG_INT2:Int , 64 , Signed ) , 64 , true
 ┃  │   span: 177
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_i8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_INT1:Int , 8 , true ) , Integer
 │   span: 53
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int *Int ARG_INT2:Int , 8 , Signed ) , 8 , true )
 ┃  │   span: 53
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_UINT1:Int , 128 , false ) , Inte
 │   span: 332
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int *Int ARG_UINT2:Int &Int 34028236692093846346337460743176
 ┃  │   span: 332
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_UINT1:Int , 16 , false ) , Integ
 │   span: 208
@@ -16,7 +16,7 @@
 ~> #freezer
 ┃  │   span: 208
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_UINT1:Int , 32 , false ) , Integ
 │   span: 239
@@ -16,7 +16,7 @@
 ~> #fr
 ┃  │   span: 239
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_UINT1:Int , 64 , false ) , Integ
 │   span: 270
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int *Int ARG_UINT2:Int &Int 18446744073709551615 , 64 , fals
 ┃  │   span: 270
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_mul-fail.unchecked_mul_u8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpMulUnchecked , Integer ( ARG_UINT1:Int , 8 , false ) , Intege
 │   span: 84
@@ -16,7 +16,7 @@
 ~> #freezer#se
 ┃  │   span: 84
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (50 steps)
+│  (52 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( 0 , 128 , true ) , Integer ( ARG_INT
 │   span: 178
@@ -16,7 +16,7 @@
 ~> #fre
 ┃  │   span: 178
 ┃  │
-┃  │  (67 steps)
+┃  │  (68 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (50 steps)
+│  (52 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( 0 , 16 , true ) , Integer ( ARG_INT1
 │   span: 91
@@ -16,7 +16,7 @@
 ~> #freez
 ┃  │   span: 91
 ┃  │
-┃  │  (67 steps)
+┃  │  (68 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (50 steps)
+│  (52 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( 0 , 32 , true ) , Integer ( ARG_INT1
 │   span: 120
@@ -16,7 +16,7 @@
 ~> #freez
 ┃  │   span: 120
 ┃  │
-┃  │  (67 steps)
+┃  │  (68 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (50 steps)
+│  (52 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( 0 , 64 , true ) , Integer ( ARG_INT1
 │   span: 149
@@ -16,7 +16,7 @@
 ~> #freez
 ┃  │   span: 149
 ┃  │
-┃  │  (67 steps)
+┃  │  (68 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_neg-fail.unchecked_neg_i8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (50 steps)
+│  (52 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( 0 , 8 , true ) , Integer ( ARG_INT1:
 │   span: 58
@@ -16,7 +16,7 @@
 ~> #freezer
 ┃  │   span: 58
 ┃  │
-┃  │  (67 steps)
+┃  │  (68 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_INT1:Int , 128 , true ) , Intege
 │   span: 274
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int <<Int ARG_UINT2:Int modInt 3402823669209384634
 ┃  │   span: 274
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_INT1:Int , 16 , true ) , Integer
 │   span: 112
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int <<Int ARG_UINT2:Int modInt 65536 , 16 , Signed
 ┃  │   span: 112
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_INT1:Int , 32 , true ) , Integer
 │   span: 139
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int <<Int ARG_UINT2:Int modInt 4294967296 , 32 , S
 ┃  │   span: 139
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_INT1:Int , 64 , true ) , Integer
 │   span: 166
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int <<Int ARG_UINT2:Int modInt 1844674407370955161
 ┃  │   span: 166
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_i8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_INT1:Int , 8 , true ) , Integer
 │   span: 58
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int <<Int ARG_UINT2:Int modInt 256 , 8 , Signed )
 ┃  │   span: 58
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_UINT1:Int , 128 , false ) , Inte
 │   span: 301
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int <<Int ARG_UINT2:Int modInt 34028236692093846346337460743
 ┃  │   span: 301
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_UINT1:Int , 16 , false ) , Integ
 │   span: 193
@@ -16,7 +16,7 @@
 ~> #free
 ┃  │   span: 193
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_UINT1:Int , 32 , false ) , Integ
 │   span: 220
@@ -16,7 +16,7 @@
 ~>
 ┃  │   span: 220
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_UINT1:Int , 64 , false ) , Integ
 │   span: 247
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int <<Int ARG_UINT2:Int modInt 18446744073709551616 , 64 , f
 ┃  │   span: 247
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shl-fail.unchecked_shl_u8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShlUnchecked , Integer ( ARG_UINT1:Int , 8 , false ) , Intege
 │   span: 85
@@ -16,7 +16,7 @@
 ~> #freezer
 ┃  │   span: 85
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_INT1:Int , 128 , true ) , Intege
 │   span: 274
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int >>Int ARG_UINT2:Int modInt 3402823669209384634
 ┃  │   span: 274
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_INT1:Int , 16 , true ) , Integer
 │   span: 112
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int >>Int ARG_UINT2:Int modInt 65536 , 16 , Signed
 ┃  │   span: 112
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_INT1:Int , 32 , true ) , Integer
 │   span: 139
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int >>Int ARG_UINT2:Int modInt 4294967296 , 32 , S
 ┃  │   span: 139
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_INT1:Int , 64 , true ) , Integer
 │   span: 166
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int >>Int ARG_UINT2:Int modInt 1844674407370955161
 ┃  │   span: 166
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_i8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_INT1:Int , 8 , true ) , Integer
 │   span: 58
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int >>Int ARG_UINT2:Int modInt 256 , 8 , Signed )
 ┃  │   span: 58
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_UINT1:Int , 128 , false ) , Inte
 │   span: 301
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int >>Int ARG_UINT2:Int modInt 34028236692093846346337460743
 ┃  │   span: 301
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_UINT1:Int , 16 , false ) , Integ
 │   span: 193
@@ -16,7 +16,7 @@
 ~> #free
 ┃  │   span: 193
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_UINT1:Int , 32 , false ) , Integ
 │   span: 220
@@ -16,7 +16,7 @@
 ~>
 ┃  │   span: 220
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_UINT1:Int , 64 , false ) , Integ
 │   span: 247
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int >>Int ARG_UINT2:Int modInt 18446744073709551616 , 64 , f
 ┃  │   span: 247
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_shr-fail.unchecked_shr_u8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpShrUnchecked , Integer ( ARG_UINT1:Int , 8 , false ) , Intege
 │   span: 85
@@ -16,7 +16,7 @@
 ~> #freezer
 ┃  │   span: 85
 ┃  │
-┃  │  (110 steps)
+┃  │  (111 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_INT1:Int , 128 , true ) , Intege
 │   span: 301
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int -Int ARG_INT2:Int , 128 , Signed ) , 128 , tru
 ┃  │   span: 301
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_INT1:Int , 16 , true ) , Integer
 │   span: 115
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int -Int ARG_INT2:Int , 16 , Signed ) , 16 , true
 ┃  │   span: 115
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_INT1:Int , 32 , true ) , Integer
 │   span: 146
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int -Int ARG_INT2:Int , 32 , Signed ) , 32 , true
 ┃  │   span: 146
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_INT1:Int , 64 , true ) , Integer
 │   span: 177
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int -Int ARG_INT2:Int , 64 , Signed ) , 64 , true
 ┃  │   span: 177
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_i8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_INT1:Int , 8 , true ) , Integer
 │   span: 53
@@ -15,7 +15,7 @@
 ┃  │   Integer ( truncate ( ARG_INT1:Int -Int ARG_INT2:Int , 8 , Signed ) , 8 , true )
 ┃  │   span: 53
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u128.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u128.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_UINT1:Int , 128 , false ) , Inte
 │   span: 332
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int -Int ARG_UINT2:Int &Int 34028236692093846346337460743176
 ┃  │   span: 332
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u16.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u16.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_UINT1:Int , 16 , false ) , Integ
 │   span: 208
@@ -16,7 +16,7 @@
 ~> #freezer
 ┃  │   span: 208
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u32.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u32.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_UINT1:Int , 32 , false ) , Integ
 │   span: 239
@@ -16,7 +16,7 @@
 ~> #fr
 ┃  │   span: 239
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u64.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u64.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_UINT1:Int , 64 , false ) , Integ
 │   span: 270
@@ -15,7 +15,7 @@
 ┃  │   Integer ( ARG_UINT1:Int -Int ARG_UINT2:Int &Int 18446744073709551615 , 64 , fals
 ┃  │   span: 270
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u8.expected
+++ b/kmir/src/tests/integration/data/verify-rust-std/0011-floats-ints/show/unchecked_sub-fail.unchecked_sub_u8.expected
@@ -3,7 +3,7 @@
 │   #execTerminator ( terminator ( ... kind: terminatorKindCall ( ... func: operandC
 │   span: 0
 │
-│  (56 steps)
+│  (58 steps)
 ├─ 3
 │   #applyBinOp ( binOpSubUnchecked , Integer ( ARG_UINT1:Int , 8 , false ) , Intege
 │   span: 84
@@ -16,7 +16,7 @@
 ~> #freezer#se
 ┃  │   span: 84
 ┃  │
-┃  │  (70 steps)
+┃  │  (71 steps)
 ┃  ├─ 6 (terminal)
 ┃  │   #EndProgram ~> .K
 ┃  │

--- a/kmir/src/tests/integration/test_integration.py
+++ b/kmir/src/tests/integration/test_integration.py
@@ -403,16 +403,16 @@ EXEC_DATA = [
         None,
     ),
     (
-        'main-a-b-c --depth 20',
+        'main-a-b-c --depth 28',
         EXEC_DATA_DIR / 'main-a-b-c' / 'main-a-b-c.smir.json',
         EXEC_DATA_DIR / 'main-a-b-c' / 'main-a-b-c.state',
-        24,
+        28,
     ),
     (
         'call-with-args',
         EXEC_DATA_DIR / 'call-with-args' / 'main-a-b-with-int.smir.json',
         EXEC_DATA_DIR / 'call-with-args' / 'main-a-b-with-int.state',
-        33,
+        36,
     ),
     (
         'closure-call',
@@ -430,7 +430,7 @@ EXEC_DATA = [
         'structs-tuples',
         EXEC_DATA_DIR / 'structs-tuples' / 'structs-tuples.smir.json',
         EXEC_DATA_DIR / 'structs-tuples' / 'structs-tuples.state',
-        101,
+        103,
     ),
     (
         'struct-field-update',
@@ -498,7 +498,7 @@ EXEC_DATA = [
         EXEC_DATA_DIR / 'references' / 'weirdRefs.state',
         None,
     ),
-    ('enum-discriminants', EXEC_DATA_DIR / 'enum' / 'enum.smir.json', EXEC_DATA_DIR / 'enum' / 'enum.state', 136),
+    ('enum-discriminants', EXEC_DATA_DIR / 'enum' / 'enum.smir.json', EXEC_DATA_DIR / 'enum' / 'enum.state', 137),
     (
         'Array-indexing',
         EXEC_DATA_DIR / 'arrays' / 'array_indexing.smir.json',
@@ -527,7 +527,7 @@ EXEC_DATA = [
         'pointer-cast-zst',
         EXEC_DATA_DIR / 'pointers' / 'pointer-cast-zst.smir.json',
         EXEC_DATA_DIR / 'pointers' / 'pointer-cast-zst.state',
-        50,
+        52,
     ),
     (
         'ref-ptr-cases',


### PR DESCRIPTION
We currently have duplicated rules for function selector check, which makes maintaining them a bit more fragile/brittle. This deduplicates them by sequentializing the check.

In particular:

- Introduce extra step `#checkFunctionFilter(...)` for creating cut-rules where we have function calls we want to inspect.
- Update tests that now need to take extra steps to get to the same state.
- Update test expected output where relevant.

In addition, this makes a minor update to the `CLAUDE.md` with more fine-grained information about how to run tests and update expected output autonomously.