### PR TITLE
Use default LLVM lib directory when resuming a proof without recompilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: 'Get uv release'
         id: uv_release
         run: |
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: 'Get uv release'
         id: uv_release
         run: |
@@ -84,7 +84,7 @@ jobs:
             timeout: 60
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: 'Set up Docker'
@@ -107,7 +107,7 @@ jobs:
     runs-on: [self-hosted, linux, normal]
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: 'Set up Docker'
@@ -137,7 +137,7 @@ jobs:
       short-sha: ${{ steps.set-image-name.outputs.short-sha }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -215,7 +215,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: 'Check out code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Check out pull request HEAD instead of merge commit.
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,6 @@ jobs:
       - name: 'Check out code'
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.JENKINS_GITHUB_PAT }}
           submodules: recursive
       - name: 'Set up Docker'
         uses: ./.github/actions/with-docker
@@ -110,7 +109,6 @@ jobs:
       - name: 'Check out code'
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.JENKINS_GITHUB_PAT }}
           submodules: recursive
       - name: 'Set up Docker'
         uses: ./.github/actions/with-docker
@@ -212,7 +210,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [normal, MacM1]  # MacM1 / normal are self-hosted, 
+        runner: [normal, MacM1]  # MacM1 / normal are self-hosted,
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     steps:
@@ -243,4 +241,3 @@ jobs:
           set -euxo pipefail
           nix --version
           nix flake check # build and run smoke test
-

--- a/kmir/src/kmir/kompile.py
+++ b/kmir/src/kmir/kompile.py
@@ -256,13 +256,12 @@ def kompile_smir(
     )
 
     target_hs_path = target_dir / 'haskell'
-    target_llvm_lib_path = target_dir / 'llvm-library'
     target_llvm_path = target_dir / 'llvm'
 
     if kompile_digest == expected_digest:
         _LOGGER.info(f'Kompiled SMIR up-to-date, no kompilation necessary: {target_dir}')
         if symbolic:
-            return KompiledSymbolic(haskell_dir=target_hs_path, llvm_lib_dir=target_llvm_lib_path)
+            return KompiledSymbolic(haskell_dir=target_hs_path, llvm_lib_dir=kdist.which(llvm_lib_target))
         else:
             return KompiledConcrete(llvm_dir=target_llvm_path)
 


### PR DESCRIPTION
Since the definition is not recompiled any more for specific programs with the LLVM backend, the `KompiledSymbolic` class always uses the standard LLVM backend library from the semantics.precompiled definition. The execution path for reloading a proof without having to re-process the definition.kore was still using a custom value where the compiled LLVM backend library was previously stored.

To reproduce the bug:
1. Run a proof: `kmir prove my_program.rs --proof-dir fubar`
2. Re-run the proof (without `--reload`, same command as above)

The parameter for the LLVM backend library in `KompiledSymbolic` is maybe still used in other contexts but could be omitted for this use.